### PR TITLE
Text component failed to render 0

### DIFF
--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -60,7 +60,11 @@ export default () =>
     ],
     computed: {
       text() {
-        return this.slotcontent || this.content || ''
+        return (
+          this.slotcontent ||
+          this.content ||
+          (this.slotcontent === 0 ? this.slotcontent : this.content === 0 ? this.content : '')
+        )
       },
       _contain() {
         return this.contain || (this.align ? 'width' : null)


### PR DESCRIPTION
[Issue]
Found Text component failed to render 0 (numeric) value

[Reason]
Logical OR statment in computed method 'text' in Text component

[Fix]
Added check for zero value for both slotContent and content