### PR TITLE
Fix text node without text

### DIFF
--- a/src/element.js
+++ b/src/element.js
@@ -133,7 +133,7 @@ const transformations = {
     props.rotation = props.rotation * (Math.PI / 180)
   },
   text(props) {
-    props.text = props.text.toString()
+    props.text = props.text?.toString()
   },
   textureColor(props) {
     if (!('color' in props)) {


### PR DESCRIPTION
This fixes an error showing when an empty text node is in the template:

`<Text ref="hello"></Text>`