### PR TITLE
Fixes some template parsing bugs and improves validation

### DIFF
--- a/src/lib/templateparser/parser.test.js
+++ b/src/lib/templateparser/parser.test.js
@@ -947,3 +947,102 @@ test('Parse template with attribute values with delimited either single or doubl
   assert.deepEqual(actual, expected, 'Parser should return object representation of template')
   assert.end()
 })
+
+test('Parse template with multiple top level elements and parsing should fail', (assert) => {
+  const template = `
+  <Component>
+    <Element
+      w='160' h="160" x='40' y='40' color="#fb923c"
+      :effects='[$shader(
+        "radius",
+        {radius: 44}
+      )]'
+    />
+  </Component>
+  <Component>
+    <Element
+      w='120' h="120"
+      x='100' y="100"
+      :effects="[
+        $shader(
+          'radius',
+          {
+            radius: 45
+          }
+        )
+      ]"
+    />
+  </Component>`
+
+  const actual = parser(template)
+  assert.equal(actual, null, 'Parser should throw an error')
+
+  assert.end()
+})
+
+test('Parse template with unclosed tag and parsing should fail', (assert) => {
+  const template = `
+  <Component>
+    <Element>
+  </Component>
+  `
+
+  const actual = parser(template)
+  assert.equal(actual, null, 'Parser should throw an error')
+  assert.end()
+})
+
+test('Parse template with multiple unclosed tags and parsing should fail', (assert) => {
+  const template = `
+  <Component>
+    <Element>
+      <Button />
+      <Text>Lorem Ipsum</Text>
+      <Element>
+        <Button />
+        <Text>Lorem Ipsum</Text>
+  </Component>
+  `
+
+  const actual = parser(template)
+  assert.equal(actual, null, 'Parser should throw an error')
+  assert.end()
+})
+
+test('Parse template with an invalid closing tag and parsing should fail', (assert) => {
+  const template = `
+  <Component>
+    <Element>
+    </Element/>
+  </Component>
+  `
+
+  const actual = parser(template)
+  assert.equal(actual, null, 'Parser should throw an error')
+
+  assert.end()
+})
+
+test('Parse template with multiple self-closing tags at the top level and parsing should fail', (assert) => {
+  const template = `
+  <Component/>
+  <Element/>
+  `
+
+  const actual = parser(template)
+  assert.equal(actual, null, 'Parser should throw an error')
+  assert.end()
+})
+
+test('Parse template with a closing tag at the beginning and parsing should fail', (assert) => {
+  const template = `
+  </Element>
+  <Component>
+    <Element/>
+  </Component>
+  `
+
+  const actual = parser(template)
+  assert.equal(actual, null, 'Parser should throw an error')
+  assert.end()
+})


### PR DESCRIPTION
- Enforces having only one container tag at the top level of templates. It can be a single self-closing tag (without no other tags) or a classing opening/closing tag pairs encloses all the other tags.
- Fixed a bug that prevents parser to correctly identify non-closed opening tags.
- Checks also if there is any closing tags without an opening tag.
- Fixed a bug that causes the parser to incorrectly mark `</Tag/>` or similar tags as valid self-closing tags.
- Added more tests (mainly testing the cases where the parser must fail due to invalid templates)
- `format()` function is replaced with a better one.
- moved `parseLoop()` into the try-catch block and `format()` function was moved before. 