### PR TITLE
Feature/custom shaders

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,18 +31,18 @@
   "devDependencies": {
     "babel-eslint": "^10.1.0",
     "c8": "^8.0.1",
-    "eslint": "^8.8.0",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-prettier": "^4.0.0",
+    "eslint": "^8.54.0",
+    "eslint-config-prettier": "^8.10.0",
+    "eslint-plugin-prettier": "^4.2.1",
     "esm": "^3.2.25",
     "husky": "^7.0.4",
-    "lint-staged": "^12.3.3",
-    "prettier": "^2.5.1",
+    "lint-staged": "^12.5.0",
+    "prettier": "^2.8.8",
     "tap-diff": "^0.1.1",
-    "tape": "^5.5.0"
+    "tape": "^5.7.2"
   },
   "dependencies": {
-    "@lightningjs/renderer": "^0.5.0",
+    "@lightningjs/renderer": "github:lightning-js/renderer#fix/dynamic-shader-effects",
     "@lightningjs/vite-plugin-import-chunk-url": "^0.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,18 +31,18 @@
   "devDependencies": {
     "babel-eslint": "^10.1.0",
     "c8": "^8.0.1",
-    "eslint": "^8.54.0",
-    "eslint-config-prettier": "^8.10.0",
-    "eslint-plugin-prettier": "^4.2.1",
+    "eslint": "^8.8.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-prettier": "^4.0.0",
     "esm": "^3.2.25",
     "husky": "^7.0.4",
-    "lint-staged": "^12.5.0",
-    "prettier": "^2.8.8",
+    "lint-staged": "^12.3.3",
+    "prettier": "^2.5.1",
     "tap-diff": "^0.1.1",
-    "tape": "^5.7.2"
+    "tape": "^5.5.0"
   },
   "dependencies": {
-    "@lightningjs/renderer": "github:lightning-js/renderer#fix/dynamic-shader-effects",
+    "@lightningjs/renderer": "^0.5.0",
     "@lightningjs/vite-plugin-import-chunk-url": "^0.3.0"
   }
 }

--- a/src/lib/setup/base.js
+++ b/src/lib/setup/base.js
@@ -41,6 +41,10 @@ const shaders = {
   glitch: 'glitch',
 }
 
+const remap = {
+  rounded: 'radius',
+}
+
 export default (component) => {
   Object.defineProperties(component.prototype, {
     focus: {
@@ -101,9 +105,12 @@ export default (component) => {
     },
     shader: {
       value: function (type, args) {
-        if (type in shaders) {
+        const target = remap[type] || type
+        const shaders = renderer.driver.stage.shManager.getRegisteredEffects()
+
+        if (target in shaders) {
           return {
-            type: shaders[type],
+            type: target,
             props: args,
           }
         } else {

--- a/src/lib/setup/base.js
+++ b/src/lib/setup/base.js
@@ -29,19 +29,7 @@ import symbols from '../symbols.js'
 
 import { trigger } from '../reactivity/effect.js'
 
-const shaders = {
-  radius: 'radius',
-  rounded: 'radius',
-  border: 'border',
-  borderTop: 'borderTop',
-  borderBottom: 'borderBottom',
-  borderLeft: 'borderLeft',
-  borderRight: 'borderRight',
-  grayScale: 'grayscale',
-  glitch: 'glitch',
-}
-
-const remap = {
+const shaderAlias = {
   rounded: 'radius',
 }
 
@@ -105,7 +93,7 @@ export default (component) => {
     },
     shader: {
       value: function (type, args) {
-        const target = remap[type] || type
+        const target = shaderAlias[type] || type
         const shaders = renderer.driver.stage.shManager.getRegisteredEffects()
 
         if (target in shaders) {


### PR DESCRIPTION
Base.js

- removed shaders object
- added shaderAlias object containing pointers to other shader types.
- use the renderer's shadermanager to check which shader types / effects are available.

Depends on:

https://github.com/lightning-js/renderer/pull/89