### PR TITLE
Fixes unescaped single quotes issue for content values

### DIFF
--- a/src/lib/codegenerator/generator.js
+++ b/src/lib/codegenerator/generator.js
@@ -316,7 +316,8 @@ const cast = (val = '', key = false, component = 'component.') => {
     if (val.startsWith('$')) {
       castedValue = `${component}${val.replace('$', '')}`
     } else {
-      castedValue = `'${parseInlineContent(val, component)}'`
+      // unescaped single quotes must be escaped
+      castedValue = `'${parseInlineContent(val.replace(/(?<!\\)'/g, "\\'"), component)}'`
     }
   }
   // numeric


### PR DESCRIPTION
Unescaped single quotes in the `content` attribute of a `Text` tag lead to syntax errors in the code generated by the `cast` function:

```html
<Text content="Let's play" />
```

creates a problem whereas 

```html
<Text content="Let\'s play" />
```

works without an issue.

The fix checks if there are any unescaped single quotes in the `content` value and escapes it properly. 