### PR TITLE
Fixes path resolution in the boilerplate code for subfolder deployment

### DIFF
--- a/boilerplate/index.html
+++ b/boilerplate/index.html
@@ -6,6 +6,6 @@
     </head>
     <body>
         <div id="app"></div>
-        <script type="module" src="/src/index.js"></script>
+        <script type="module" src="src/index.js"></script>
     </body>
 </html>

--- a/boilerplate/src/index.js
+++ b/boilerplate/src/index.js
@@ -11,8 +11,22 @@ Blits.Launch(App, 'app', {
   debugLevel: 1,
   fontLoader: fontLoader,
   fonts: [
-    {family: 'lato', type: 'msdf', png: '/fonts/Lato-Regular.msdf.png', json: '/fonts/Lato-Regular.msdf.json'},
-    {family: 'raleway', type: 'msdf', png: '/fonts/Raleway-ExtraBold.msdf.png', json: '/fonts/Raleway-ExtraBold.msdf.json'},
-    {family: 'opensans', type: 'web', file: '/fonts/OpenSans-Medium.ttf'}
+    {
+      family: 'lato',
+      type: 'msdf',
+      png: 'fonts/Lato-Regular.msdf.png',
+      json: 'fonts/Lato-Regular.msdf.json',
+    },
+    {
+      family: 'raleway',
+      type: 'msdf',
+      png: 'fonts/Raleway-ExtraBold.msdf.png',
+      json: 'fonts/Raleway-ExtraBold.msdf.json',
+    },
+    {
+      family: 'opensans',
+      type: 'web',
+      file: 'fonts/OpenSans-Medium.ttf',
+    },
   ],
 })

--- a/boilerplate/vite.config.js
+++ b/boilerplate/vite.config.js
@@ -3,6 +3,7 @@ import blitsVitePlugins from '@lightningjs/blits/vite'
 
 export default defineConfig(({ command, mode, ssrBuild }) => {
   return {
+    base: '/', // Set to your base path if you are deploying to a subdirectory (example: /myApp/)
     plugins: [...blitsVitePlugins],
     resolve: {
       mainFields: ['browser', 'module', 'jsnext:main', 'jsnext'],


### PR DESCRIPTION
Converts all absolute paths to relative ones in the boilerplate code and adds a `base` configuration in `vite.config.js` (default value is `/`).