### PR TITLE
fixed single quote escaping for all browsers

### DIFF
--- a/src/lib/codegenerator/generator.js
+++ b/src/lib/codegenerator/generator.js
@@ -326,8 +326,12 @@ const cast = (val = '', key = false, component = 'component.') => {
     if (val.startsWith('$')) {
       castedValue = `${component}${val.replace('$', '')}`
     } else {
-      // unescaped single quotes must be escaped
-      castedValue = `'${parseInlineContent(val.replace(/(?<!\\)'/g, "\\'"), component)}'`
+      // unescaped single quotes must be escaped while preserving escaped backslashes
+      const escapedVal = val
+        .replace(/\\\\/g, '__DOUBLE_BACKSLASH__')
+        .replace(/(^|[^\\])'/g, "$1\\'")
+        .replace(/__DOUBLE_BACKSLASH__/g, '\\\\')
+      castedValue = `'${parseInlineContent(escapedVal, component)}'`
     }
   }
   // numeric


### PR DESCRIPTION
This solution should work in all browsers including older versions of Safari which do not support negative lookahead in regular expressions.

This version also fixes some problems of the previous implementation like handling such cases:

```html
<Element content="Let\\\\'s play" />
```