### PR TITLE
Expose inspector setting

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -46,6 +46,7 @@ module.exports = {
         tabWidth: 2,
         semi: false,
         printWidth: 100,
+        endOfLine: 'auto',
       },
     ],
   },

--- a/src/launch.d.ts
+++ b/src/launch.d.ts
@@ -172,6 +172,15 @@ export interface Settings {
    *
    */
   canvasColor?: string,
+  /**
+   * Enable inspector
+   *
+   * Enables the inspector tool for debugging and inspecting the application, the node tree
+   * will be replicated in the DOM and can be inspected using the browser's developer tools
+   *
+   * Defaults to `false`
+   */
+  inspector?: boolean
 }
 
 /**

--- a/src/launch.js
+++ b/src/launch.js
@@ -52,6 +52,7 @@ export default (App, target, settings) => {
           ? settings.webWorkersLimit
           : window.navigator.hardwareConcurrency || 2,
       clearColor: (settings.canvasColor && colors.normalize(settings.canvasColor)) || 0x00000000,
+      enableInspector: settings.inspector || false,
     },
     target,
     driver


### PR DESCRIPTION
And support for non-unix filesystems, windows uses `cr` ends and prettier didn't like that very much 😨 