### PR TITLE
Implemented router before hook

### DIFF
--- a/src/application.d.ts
+++ b/src/application.d.ts
@@ -115,6 +115,11 @@ declare namespace Application {
      * politeness level
      */
     announce?: String | RouteAnnounce
+    /**
+     * Register hooks for the route
+     */
+    hooks?: object
+
   }
 
   export interface ApplicationInstance extends ComponentInstance {}

--- a/src/application.d.ts
+++ b/src/application.d.ts
@@ -93,7 +93,7 @@ declare namespace Application {
   }[keyof T]
 
   interface RouteHooks {
-    before?: (to?: Route, from?: Route) => any;
+    before?: (to: Route, from: Route) => string | Route;
   }
 
   type Route = {

--- a/src/application.d.ts
+++ b/src/application.d.ts
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2023 Comcast Cable Communications Management, LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -91,6 +92,10 @@ declare namespace Application {
     [K in keyof T]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<keyof T, K>>>
   }[keyof T]
 
+  interface RouteHooks {
+    before?: (to?: Route, from?: Route) => any;
+  }
+
   type Route = {
     /**
      * URI path for the route
@@ -118,8 +123,13 @@ declare namespace Application {
     /**
      * Register hooks for the route
      */
-    hooks?: object
-
+    hooks?: RouteHooks
+    /**
+     * Allows adding route path parameters to the params property internally 
+     */
+    readonly params?: {
+      [key: string]: string | number;
+    };
   }
 
   export interface ApplicationInstance extends ComponentInstance {}

--- a/src/application.d.ts
+++ b/src/application.d.ts
@@ -125,11 +125,21 @@ declare namespace Application {
      */
     hooks?: RouteHooks
     /**
-     * Allows adding route path parameters to the params property internally 
+     * Route path parameters
      */
     readonly params?: {
-      [key: string]: string | number;
-    };
+      [key: string]: string | number
+    }
+    /**
+     * Allows for attaching custom data to a route, either hardcoded in the
+     * route definition or asigned to the route object in a before hook
+     *
+     * Will be merged with the route params and navigation data and passed as
+     * props into the route component
+     */
+    data?: {
+      [key: string]: any
+    }
   }
 
   export interface ApplicationInstance extends ComponentInstance {}

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -118,6 +118,7 @@ export const navigate = async function () {
         if (route.hooks.before) {
           beforeHookOutput = await route.hooks.before(route, previousRoute)
           if (isString(beforeHookOutput)) {
+            currentRoute = previousRoute
             to(beforeHookOutput)
             return
           }

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -111,19 +111,19 @@ export const navigate = async function () {
   if (this.parent[symbols.routes]) {
     const previousRoute = currentRoute
     const hash = getHash()
-    const route = matchHash(hash, this.parent[symbols.routes])
+    let route = matchHash(hash, this.parent[symbols.routes])
     let beforeHookOutput
     if (route) {
       if (route.hooks) {
         if (route.hooks.before) {
-          beforeHookOutput = await route.hooks.before(route.params)
+          beforeHookOutput = await route.hooks.before(route, previousRoute)
           if (isString(beforeHookOutput)) {
             to(beforeHookOutput)
             return
           }
         }
       }
-
+      route = isObject(beforeHookOutput) ? beforeHookOutput : route
       // add the previous route (technically still the current route at this point)
       // into the history stack, unless navigating back or inHistory flag of route is false
       if (navigatingBack === false && previousRoute && previousRoute.options.inHistory === true) {
@@ -149,12 +149,7 @@ export const navigate = async function () {
         holder.set('w', '100%')
         holder.set('h', '100%')
         // merge props with potential route params to be injected into the component instance
-        const props = {
-          ...this[symbols.props],
-          ...route.params,
-          ...navigationData,
-          ...beforeHookOutput,
-        }
+        const props = { ...this[symbols.props], ...route.params, ...navigationData }
 
         view = await route.component({ props }, holder, this)
         if (view[Symbol.toStringTag] === 'Module') {

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -60,6 +60,7 @@ export const matchHash = (path, routes = []) => {
     const route = routes[i]
     route.path = normalizePath(route.path)
     if (route.path === path) {
+      route.params = {}
       matchingRoute = route
     } else if (route.path.indexOf(':') > -1) {
       // match dynamic route parts
@@ -115,15 +116,13 @@ export const navigate = async function () {
     if (route) {
       if (route.hooks) {
         if (route.hooks.before) {
-          const args = route.params ? route.params : {}
-          beforeHookOutput = await route.hooks.before(args)
+          beforeHookOutput = await route.hooks.before(route.params)
           if (isString(beforeHookOutput)) {
             to(beforeHookOutput)
             return
           }
         }
       }
-      beforeHookOutput = isObject(beforeHookOutput) ? beforeHookOutput : {}
 
       // add the previous route (technically still the current route at this point)
       // into the history stack, unless navigating back or inHistory flag of route is false

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -100,6 +100,9 @@ export const matchHash = (path, routes = []) => {
 
   if (matchingRoute) {
     matchingRoute.options = { ...matchingRoute.options, ...overrideOptions }
+    if (!matchingRoute.data) {
+      matchingRoute.data = {}
+    }
     currentRoute = matchingRoute
   }
 
@@ -149,8 +152,8 @@ export const navigate = async function () {
         holder.populate({})
         holder.set('w', '100%')
         holder.set('h', '100%')
-        // merge props with potential route params to be injected into the component instance
-        const props = { ...this[symbols.props], ...route.params, ...navigationData }
+        // merge props with potential route params, navigation data and route data to be injected into the component instance
+        const props = { ...this[symbols.props], ...route.params, ...navigationData, ...route.data }
 
         view = await route.component({ props }, holder, this)
         if (view[Symbol.toStringTag] === 'Module') {


### PR DESCRIPTION
The router before hook has access to router path parameters in the order they are defined in the router path.

The following cases are covered under router before hook

- If the before hook results in a string, navigate to the respective route.
 `  {
      path: '/xyz',
      component:  Xyz,
      hooks: {
        before: async () => {
          //check for authorization/token verification
          return '/abc';
        },
      },
    },`
- If the before hook results in object, injecting object properties as props in component
` {
      path: '/about/:type/:id',
      component: About,
      hooks: {
        async before({ type, id }) {
          const data = await getDetails(type, id)
          return { data };
        },
      },
    },`
    
