### PR TITLE
Add support for dotenv

### DIFF
--- a/boilerplate/common/eslint/.eslintrc.cjs
+++ b/boilerplate/common/eslint/.eslintrc.cjs
@@ -32,7 +32,7 @@ module.exports = {
   },
   parserOptions: {
     parser: 'babel-eslint',
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
     sourceType: 'module',
   },
 }

--- a/boilerplate/common/git/gitignore
+++ b/boilerplate/common/git/gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .env
 .env.*
+!.env.example
 
 node_modules
 build

--- a/boilerplate/common/git/gitignore
+++ b/boilerplate/common/git/gitignore
@@ -1,5 +1,7 @@
 .DS_Store
+.env
+.env.*
+
 node_modules
 build
 dist
-env

--- a/boilerplate/js/default/.env.example
+++ b/boilerplate/js/default/.env.example
@@ -1,0 +1,4 @@
+# all environment variables need to prefixed with VITE_*
+# to read, use import.meta.env.VITE_FOO
+
+# VITE_FOO=bar

--- a/boilerplate/js/default/src/pages/Home.js
+++ b/boilerplate/js/default/src/pages/Home.js
@@ -2,7 +2,7 @@ import Blits from '@lightningjs/blits'
 
 import Loader from '../components/Loader.js'
 
-export default Blits.Component('Loading', {
+export default Blits.Component('Home', {
   components: {
     Loader,
   },

--- a/boilerplate/js/default/vite.config.js
+++ b/boilerplate/js/default/vite.config.js
@@ -1,3 +1,5 @@
+/// <reference types="vite/client" />
+
 import { defineConfig } from 'vite'
 import blitsVitePlugins from '@lightningjs/blits/vite'
 


### PR DESCRIPTION
I tried to add a `.env` file to the boilerplate project I got from `npx @lightningjs/blits@latest` but ran into a few errors. This PR changes the boilerplate code so that `.env.*` files can be used.

## Changes
- Example `.env.example` file added.
- `.gitignore` ignores any `.env` files.
- `ecmaVersion` in `eslintrc.cjs` uses `2020`.
- Added `/// <reference types="vite/client" />` to `vite.config.js`
- Fix component name in `Home.js`.