### PR TITLE
Remove event listeners of previous route component

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -22,6 +22,7 @@ import { Log } from '../lib/log.js'
 import { stage } from '../launch.js'
 import Focus from '../focus.js'
 import Announcer from '../announcer/announcer.js'
+import eventListeners from '../lib/eventListeners.js'
 
 export let currentRoute
 export let navigating = false
@@ -141,6 +142,11 @@ export const navigate = async function () {
       // based on current and previous route
       if (typeof route.transition === 'function') {
         route.transition = route.transition(previousRoute, route)
+      }
+
+      // remove event listeners from current active view
+      if (previousRoute) {
+        eventListeners.removeListeners(this.activeView)
       }
 
       let holder


### PR DESCRIPTION
Removing event listeners of previous route component before creating target(next) route component instance.