### PR TITLE
Precompiler fix: checks objects with template property

### DIFF
--- a/src/lib/precompiler/precompiler.js
+++ b/src/lib/precompiler/precompiler.js
@@ -23,7 +23,8 @@ export default (source, filePath) => {
   if (
     source.indexOf('Blits.Component(') > -1 ||
     source.indexOf('Blits.Application(') > -1 ||
-    /=>\s*Component\(['"][A-Za-z]+['"],/s.test(source) // blits component
+    /=>\s*Component\(['"][A-Za-z]+['"],/s.test(source) || // blits component
+    /\{.*?template\s*:\s*(['"`])((?:\\?.)*?)\1.*?\}/s.test(source) // object with template key
   ) {
     const templates = source.matchAll(/(?<!\/\/\s*)template\s*:\s*(['"`])((?:\\?.)*?)\1/gs)
     let newSource = source


### PR DESCRIPTION
This is a quick fix for the case where config object gets template property from another object. Now the precompiler also checks objects with `template` property.

```js
const myTemplate = {
  template: '
    <Element x="620" y="20">
     <Element w="300" h="200" />
    </Element>'
}

export default Blits.Component('myComp', {
...myTemplate
})
```