### PR TITLE
Resolve Typescript error with both Props keys

### DIFF
--- a/src/component.d.ts
+++ b/src/component.d.ts
@@ -91,6 +91,7 @@ declare namespace Component {
   }
   type PropsArray<T extends string> = T[]
   type AdvancedProps = AdvancedProp[]
+  type MixedProps<T extends string> = (T | AdvancedProp)[];
 
   // type ExtractPropNames<T extends Prop[]> = T extends (infer U)[]
   // ? U extends string
@@ -394,7 +395,7 @@ declare namespace Component {
      * }]
      * ```
      */
-    props?: PropsArray<Props> | AdvancedProp[],
+    props?: PropsArray<Props> | AdvancedProps | MixedProps<Props>
     /**
      * Computed properties
      */


### PR DESCRIPTION
Observed typescript error while adding normal string props and advanced props in a component props key. 

Allowing only one kind of keys but not both