### PR TITLE
Precompiler changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "exports": {
     ".": "./index.js",
     "./vite": "./vite/index.js",
-    "./transitions": "./src/router/transitions/index.js"
+    "./transitions": "./src/router/transitions/index.js",
+    "./precompiler": "./src/lib/precompiler/precompiler.js"
   },
   "scripts": {
     "test": "c8 npm run test:run",

--- a/src/lib/precompiler/precompiler.js
+++ b/src/lib/precompiler/precompiler.js
@@ -17,7 +17,6 @@
 
 import parser from '../templateparser/parser.js'
 import generator from '../codegenerator/generator.js'
-import path from 'path'
 
 export default (source, filePath) => {
   if (
@@ -45,8 +44,7 @@ export default (source, filePath) => {
           resourceName = source.match(/Blits\.Component\(['"](.*)['"]\s*,/)[1]
         }
 
-        const componentPath = path.relative(process.cwd(), filePath)
-        const parsed = parser(templateContent, resourceName, null, componentPath)
+        const parsed = parser(templateContent, resourceName, null, filePath)
 
         // Generate the code
         const code = generator.call({ components: {} }, parsed)

--- a/vite/preCompiler.js
+++ b/vite/preCompiler.js
@@ -16,6 +16,7 @@
  */
 
 import compiler from '../src/lib/precompiler/precompiler.js'
+import path from 'path'
 
 export default function () {
   let config
@@ -26,7 +27,8 @@ export default function () {
     },
     transform(source, filePath) {
       if (config.blits && config.blits.precompile === false) return source
-      return compiler(source, filePath)
+      const relativePath = path.relative(process.cwd(), filePath)
+      return compiler(source, relativePath)
     },
   }
 }


### PR DESCRIPTION
Moved relative path line from /lib/ to /vite/, this removes the dependency to path in the /lib/ folder, which in turn allows us to use the precompiler on the playground.

Added precompiler to exports in package.json
