### PR TITLE
Fixes default key in for-loop for delete operation

### DIFF
--- a/src/lib/codegenerator/generator.js
+++ b/src/lib/codegenerator/generator.js
@@ -287,7 +287,9 @@ const generateForLoopCode = function (templateObject, parent) {
     const created${forStartCounter} = []
     const forloop${forStartCounter} = (collection = [], elms, created) => {
       const rawCollection = getRaw(collection)
-      const keys = new Set(rawCollection.map((${item}) => '' +  ${interpolate(key, '')}))
+      const keys = new Set(rawCollection.map((${item}, index) => ${
+    key ? interpolate(key, '') : 'index'
+  }))
   `)
 
   // keep track of the index in the render code so we can inject


### PR DESCRIPTION
When key attribute is not provided in template then considering index as key, these keys will be used to delete previous elements.

Before this fix, keys are 'undefined' so everytime all elements are deleted and created again