### PR TITLE
Optional priority-based event listener

### DIFF
--- a/src/component.d.ts
+++ b/src/component.d.ts
@@ -265,7 +265,10 @@ declare namespace Component {
     /**
     * Listen to events emitted by other components
     */
-    $listen: (event: string, callback: (args: any) => void) => void
+    $listen: {
+      (event: string, callback: (args: any) => void): void;
+      (event: string, callback: (args: any) => void, priority: number): void;
+    }
 
     /**
     * Emit events that other components can listen to

--- a/src/component/base/events.js
+++ b/src/component/base/events.js
@@ -20,15 +20,16 @@ import eventListeners from '../../lib/eventListeners.js'
 export default {
   $emit: {
     value: function (event, params) {
-      eventListeners.executeListeners(event, params)
+      // returning if all listeners executed
+      return eventListeners.executeListeners(event, params)
     },
     writable: false,
     enumerable: true,
     configurable: false,
   },
   $listen: {
-    value: function (event, callback) {
-      eventListeners.registerListener(this, event, callback)
+    value: function (event, callback, priority = 0) {
+      eventListeners.registerListener(this, event, callback, priority)
     },
     writable: false,
     enumerable: true,


### PR DESCRIPTION
- Listeners now accept an optional numeric priority parameter (higher value = higher priority, default is 0)
- Callback functions can return `false` to stop event propagation to lower-priority listeners
- Changes maintain backward compatibility with existing listener registrations and behavior
- Priority-based sorting occurs during listener registration, using an array for efficient sorting and execution
- slightly slower registration for faster event execution

An alternative version : #135 