### PR TITLE
Optional priority-based event listener (sorting in the execution phase)

### DIFF
--- a/src/component.d.ts
+++ b/src/component.d.ts
@@ -265,7 +265,10 @@ declare namespace Component {
     /**
     * Listen to events emitted by other components
     */
-    $listen: (event: string, callback: (args: any) => void) => void
+    $listen: {
+      (event: string, callback: (args: any) => void): void;
+      (event: string, callback: (args: any) => void, priority: number): void;
+    }
 
     /**
     * Emit events that other components can listen to

--- a/src/component.d.ts
+++ b/src/component.d.ts
@@ -266,8 +266,7 @@ declare namespace Component {
     * Listen to events emitted by other components
     */
     $listen: {
-      (event: string, callback: (args: any) => void): void;
-      (event: string, callback: (args: any) => void, priority: number): void;
+      (event: string, callback: (args: any) => void, priority?: number): void;
     }
 
     /**

--- a/src/component/base/events.js
+++ b/src/component/base/events.js
@@ -20,15 +20,16 @@ import eventListeners from '../../lib/eventListeners.js'
 export default {
   $emit: {
     value: function (event, params) {
-      eventListeners.executeListeners(event, params)
+      // returning if all listeners executed
+      return eventListeners.executeListeners(event, params)
     },
     writable: false,
     enumerable: true,
     configurable: false,
   },
   $listen: {
-    value: function (event, callback) {
-      eventListeners.registerListener(this, event, callback)
+    value: function (event, callback, priority = 0) {
+      eventListeners.registerListener(this, event, callback, priority)
     },
     writable: false,
     enumerable: true,

--- a/src/lib/eventListeners.js
+++ b/src/lib/eventListeners.js
@@ -16,7 +16,7 @@
  */
 
 const eventsMap = new Map()
-const cache = new Map()
+const callbackCache = new Map()
 
 export default {
   registerListener(component, event, cb, priority = 0) {
@@ -33,7 +33,7 @@ export default {
     }
 
     components.add({ cb, priority })
-    cache.delete(event) // Invalidate the cache when a new callback is added
+    callbackCache.delete(event) // Invalidate the callbackCache when a new callback is added
   },
 
   executeListeners(event, params) {
@@ -42,7 +42,7 @@ export default {
       return true // No listeners, so execution can be considered successful
     }
 
-    if (cache.has(event) === false) {
+    if (callbackCache.has(event) === false) {
       const allCallbacks = []
       for (const [component, components] of componentsMap) {
         for (const callbackObj of components) {
@@ -50,10 +50,10 @@ export default {
         }
       }
       allCallbacks.sort((a, b) => b.priority - a.priority)
-      cache.set(event, allCallbacks) // Cache the sorted callbacks with component context
+      callbackCache.set(event, allCallbacks) // callbackCache the sorted callbacks with component context
     }
 
-    const callbacks = cache.get(event)
+    const callbacks = callbackCache.get(event)
     for (let i = 0; i < callbacks.length; i++) {
       const { cb, component } = callbacks[i]
       const result = cb.call(component, params)
@@ -69,7 +69,7 @@ export default {
     for (const [event, componentsMap] of eventsMap) {
       if (componentsMap.has(component)) {
         componentsMap.delete(component)
-        cache.delete(event) // Invalidate the cache for this event
+        callbackCache.delete(event) // Invalidate the callbackCache for this event
 
         // If no more components for this event, remove the event entirely
         if (componentsMap.size === 0) {

--- a/src/lib/eventListeners.test.js
+++ b/src/lib/eventListeners.test.js
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import test from 'tape'
+import eventListener from './eventListeners.js'
+
+const resetModule = () => {
+  eventListener.removeListeners('testComponent')
+  eventListener.removeListeners('anotherComponent')
+}
+
+test('registerListener', (t) => {
+  resetModule()
+
+  const component = 'testComponent'
+  const event = 'testEvent'
+  const cb = () => {}
+
+  t.doesNotThrow(
+    () => eventListener.registerListener(component, event, cb),
+    'Should not throw exception when registering a listener'
+  )
+
+  t.doesNotThrow(
+    () => eventListener.registerListener(component, event, cb, 1),
+    'Should not throw exception when registering a listener with priority'
+  )
+
+  t.doesNotThrow(
+    () => eventListener.registerListener('anotherComponent', event, cb),
+    'Should not throw exception when registering multiple components for the same event'
+  )
+
+  t.end()
+})
+
+test('executeListeners - no listeners', (t) => {
+  resetModule()
+
+  const result = eventListener.executeListeners('nonExistentEvent')
+  t.equal(result, true, 'Should return true when no listeners are registered')
+
+  t.end()
+})
+
+test('executeListeners - with listeners', (t) => {
+  resetModule()
+
+  const component = 'testComponent'
+  const event = 'testEvent'
+  let callCount = 0
+  const cb1 = () => {
+    callCount++
+  }
+  const cb2 = () => {
+    callCount++
+  }
+
+  eventListener.registerListener(component, event, cb1)
+  eventListener.registerListener(component, event, cb2)
+
+  const result = eventListener.executeListeners(event)
+  t.equal(result, true, 'Should return true when all listeners execute successfully')
+  t.equal(callCount, 2, 'Should call all registered callbacks')
+
+  t.end()
+})
+
+test('executeListeners - priority order', (t) => {
+  resetModule()
+
+  const component = 'testComponent'
+  const event = 'testEvent'
+  const order = []
+  const cb1 = () => {
+    order.push(1)
+  }
+  const cb2 = () => {
+    order.push(2)
+  }
+  const cb3 = () => {
+    order.push(3)
+  }
+
+  eventListener.registerListener(component, event, cb1, 1)
+  eventListener.registerListener(component, event, cb2, 3)
+  eventListener.registerListener(component, event, cb3, 2)
+
+  eventListener.executeListeners(event)
+  t.deepEqual(order, [2, 3, 1], 'Should execute callbacks in priority order')
+
+  t.end()
+})
+
+test('executeListeners - stop propagation', (t) => {
+  resetModule()
+
+  const component = 'testComponent'
+  const event = 'testEvent'
+  let callCount = 0
+  const cb1 = () => {
+    callCount++
+    return false
+  }
+  const cb2 = () => {
+    callCount++
+  }
+
+  eventListener.registerListener(component, event, cb1)
+  eventListener.registerListener(component, event, cb2)
+
+  const result = eventListener.executeListeners(event)
+  t.equal(result, false, 'Should return false when propagation is stopped')
+  t.equal(callCount, 1, 'Should stop calling callbacks after one returns false')
+
+  t.end()
+})
+
+test('removeListeners', (t) => {
+  resetModule()
+
+  const component = 'testComponent'
+  const event1 = 'testEvent1'
+  const event2 = 'testEvent2'
+  const cb = () => {}
+
+  eventListener.registerListener(component, event1, cb)
+  eventListener.registerListener(component, event2, cb)
+  eventListener.registerListener('anotherComponent', event1, cb)
+
+  eventListener.removeListeners(component)
+
+  const result1 = eventListener.executeListeners(event1)
+  t.equal(result1, true, 'Should still return true for event1 as another component is registered')
+
+  const result2 = eventListener.executeListeners(event2)
+  t.equal(result2, true, 'Should return true for event2 as no listeners remain')
+
+  t.end()
+})
+
+test('cache invalidation', (t) => {
+  resetModule()
+
+  const component = 'testComponent'
+  const event = 'testEvent'
+  let callOrder = []
+  const cb1 = () => {
+    callOrder.push(1)
+  }
+  const cb2 = () => {
+    callOrder.push(2)
+  }
+
+  eventListener.registerListener(component, event, cb1)
+  eventListener.executeListeners(event)
+
+  eventListener.registerListener(component, event, cb2, 1)
+  eventListener.executeListeners(event)
+
+  t.deepEqual(callOrder, [1, 2, 1], 'Should invalidate cache when new listener is added')
+
+  callOrder = []
+  eventListener.removeListeners(component)
+  eventListener.registerListener(component, event, cb1)
+  eventListener.executeListeners(event)
+
+  t.deepEqual(callOrder, [1], 'Should invalidate cache when listeners are removed')
+
+  t.end()
+})


### PR DESCRIPTION
This version is an alternative to PR #134 by changing when we sort event listeners. Instead of sorting every time we add a listener, we wait until the event actually happens. We also save the sorted (cached) list for later use. This means we only sort listeners when we really need to.

This change minimizes unnecessary sorting operations, especially for events that may never be triggered.

- Listeners now accept an optional numeric priority parameter (higher value = higher priority, default is 0)
- Callback functions can return `false` to stop event propagation to lower-priority listeners
- Changes maintain backward compatibility with existing listener registrations and behavior
- Priority-based sorting occurs during callback execution once for each event, preventing sorting overhead.
- slightly slower first event execution for fast registration and subsequent event executions