### PR TITLE
Update Component's method names to standard format

### DIFF
--- a/src/component.d.ts
+++ b/src/component.d.ts
@@ -300,6 +300,11 @@ declare namespace Component {
     /**
     * Set focus to the Component, optionally pass a KeyboardEvent for instant event bubbling
     */
+    $focus: (event?: KeyboardEvent) => void
+    /**
+     * @deprecated
+     * Deprecated:  use `this.$focus()` instead
+     */
     focus: (event?: KeyboardEvent) => void
 
     /**
@@ -317,6 +322,12 @@ declare namespace Component {
     * }
     * ```
     */
+    $select: (ref: string) => ComponentInstance | ElementInstance
+
+    /**
+     * @deprecated
+     * Deprecated: use `this.$select()` instead
+     */
     select: (ref: string) => ComponentInstance | ElementInstance
 
     /**
@@ -345,6 +356,7 @@ declare namespace Component {
 
   export interface ElementInstance {
     focus?: () => void
+    $focus?: () => void
   }
 
   export interface ComponentConfig<Props extends string, S, M> {

--- a/src/component/base/methods.js
+++ b/src/component/base/methods.js
@@ -24,6 +24,15 @@ import { Log } from '../../lib/log.js'
 export default {
   focus: {
     value: function (e) {
+      Log.warn('this.focus is deprecated, use this.$focus instead')
+      return this.$focus(e)
+    },
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  },
+  $focus: {
+    value: function (e) {
       this[symbols.state].hasFocus = true
       Focus.set(this, e)
     },
@@ -55,6 +64,15 @@ export default {
   },
   select: {
     value: function (ref) {
+      Log.warn('this.select is deprecated, use this.$select instead')
+      return this.$select(ref)
+    },
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  },
+  $select: {
+    value: function (ref) {
       let selected = null
       this[symbols.children].forEach((child) => {
         if (Array.isArray(child)) {
@@ -77,8 +95,8 @@ export default {
   },
   trigger: {
     value: function (key) {
-      // trigger with force set to true
-      trigger(this[symbols.originalState], key, true)
+      Log.warn('this.trigger is deprecated, use this.$trigger instead')
+      return this.$trigger(key)
     },
     writable: false,
     enumerable: true,
@@ -86,8 +104,8 @@ export default {
   },
   $trigger: {
     value: function (key) {
-      Log.warn('this.$trigger is deprecated, use this.trigger instead')
-      return this.trigger(key)
+      // trigger with force set to true
+      trigger(this[symbols.originalState], key, true)
     },
     writable: false,
     enumerable: true,

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -22,7 +22,7 @@ export default () => {
       ___layout() {
         let offset = 0
 
-        this.select('slot').children.forEach((el) => {
+        this.$select('slot').children.forEach((el) => {
           el.set(this.direction === 'vertical' ? 'y' : 'x', offset)
           // todo: grab width from interface, not directly from node
           offset +=

--- a/src/components/RouterView.js
+++ b/src/components/RouterView.js
@@ -40,7 +40,7 @@ export default () =>
         window.removeEventListener('hashchange', handler, false)
       },
       focus() {
-        this.activeView && this.activeView.focus()
+        this.activeView && this.activeView.$focus()
       },
     },
     input: {


### PR DESCRIPTION
1. Updated focus, select and trigger method names by prefixing with '$'
2. Added deprecation log for previous signature of methods