### PR TITLE
Fixes some issues in theme plugin

### DIFF
--- a/src/plugins/theme.js
+++ b/src/plugins/theme.js
@@ -26,7 +26,7 @@ const getValueByDotNotation = (obj, base, path) => {
 
     if (obj !== null && key in obj === true) {
       obj = obj[key]
-      base = base[key]
+      base = base !== null && key in base === true ? base[key] : null
     }
     // see if the key is present in the base object
     else if (base !== null && key in base === true) {
@@ -34,6 +34,7 @@ const getValueByDotNotation = (obj, base, path) => {
       obj = base
     } else {
       obj = undefined
+      break
     }
   }
 


### PR DESCRIPTION
1. `break` statement addresses issue when top level key itself is not exist in base & obj. Then the for-loop  should exit without verifying second key. for example, in `colors.primary` if  `colors` key itself is not exist in base & obj then there is no point of checking for 'primary' key in next iteration of for-loop

2. Scenario where few props exist in only specific theme but not in base theme then `base = base[key]` set to `undefined` in first iteration itself. In next iteration, if key not exist in `obj` then it will check in `base` where `base !== null` becomes true eventhough base set to `undefined` so to handle this situation setting base to `null` if key is not exist in base