### PR TITLE
Fixes index reference in key attribute

### DIFF
--- a/src/lib/codegenerator/generator.js
+++ b/src/lib/codegenerator/generator.js
@@ -310,6 +310,7 @@ const generateForLoopCode = function (templateObject, parent) {
       let l = rawCollection.length
       while(l--) {
         const ${item} = rawCollection[l]
+        const ${index} = l
         keys.add('' +  ${interpolate(key, '') || 'l'})
       }
   `)

--- a/src/lib/codegenerator/generator.js
+++ b/src/lib/codegenerator/generator.js
@@ -300,6 +300,14 @@ const generateForLoopCode = function (templateObject, parent) {
     ctx.renderCode.push(`parent = ${parent}`)
   }
 
+  const indexRegex = new RegExp(`\\$${index}(?!['\\w)]`)
+  const indexResult = indexRegex.exec(key)
+  if (Array.isArray(indexResult)) {
+    ctx.renderCode.push(
+      `console.warn(" Using '${index}' in the key, like key=${key},  is not recommended")`
+    )
+  }
+
   const forStartCounter = counter
 
   ctx.renderCode.push(`


### PR DESCRIPTION
if index is used in key attribute then this fix make sure corresponding 'index' variable is available within while loop scope.

template:
```
 <Element :for="(item, index) in $data" key="$index + 'key'" > 
```
Generated code: 
```
  while(l--) {
    const item = rawCollection[l]
    const index = l
    keys.add('' +   index + 'key')
 }
```