### PR TITLE
Fix use of multiple instances of same plugin

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -7,21 +7,20 @@ export const plugins = {
 
 const registerPlugin = (plugin, nameOrOptions = '', options = {}) => {
   // map name and options depending on the arguments provided
-  let name
+  let name = undefined
   if (typeof nameOrOptions === 'object') {
     options = nameOrOptions
-    name = ''
   } else {
     name = nameOrOptions
   }
 
   if (typeof plugin === 'function') {
-    if (name === '') {
+    if (name === undefined) {
       throw Error('Error registering plugin: name is required for plugin')
     }
     plugins[name] = { plugin, options }
   } else if (plugin.plugin) {
-    registerPlugin(plugin.plugin, plugin.name, options)
+    registerPlugin(plugin.plugin, name || plugin.name, options)
   }
 }
 


### PR DESCRIPTION
This fix allows us to use multiple instances of one plugin when using a specified name.