### PR TITLE
Fixes cached router view holder's alpha issue

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -170,23 +170,23 @@ export const navigate = async function () {
         holder = view[symbols.holder]
 
         // Check, whether cached view holder's alpha prop is exists in transition or not
-        let isAlphaPropExists = false
+        let hasAlphaProp = false
         if (route.transition.before) {
           if (Array.isArray(route.transition.before)) {
             for (let i = 0; i < route.transition.before.length; i++) {
               if (route.transition.before[i].prop === 'alpha') {
-                isAlphaPropExists = true
+                hasAlphaProp = true
                 break
               }
             }
           } else {
             if (route.transition.before.prop === 'alpha') {
-              isAlphaPropExists = true
+              hasAlphaProp = true
             }
           }
         }
         // set holder alpha when alpha prop is not exists in route transition
-        if (!isAlphaPropExists) {
+        if (!hasAlphaProp) {
           holder.set('alpha', 1)
         }
       }

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -179,14 +179,12 @@ export const navigate = async function () {
                 break
               }
             }
-          } else {
-            if (route.transition.before.prop === 'alpha') {
-              hasAlphaProp = true
-            }
+          } else if (route.transition.before.prop === 'alpha') {
+            hasAlphaProp = true
           }
         }
         // set holder alpha when alpha prop is not exists in route transition
-        if (!hasAlphaProp) {
+        if (hasAlphaProp === false) {
           holder.set('alpha', 1)
         }
       }

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -168,6 +168,27 @@ export const navigate = async function () {
         }
       } else {
         holder = view[symbols.holder]
+
+        // Check, whether cached view holder's alpha prop is exists in transition or not
+        let isAlphaPropExists = false
+        if (route.transition.before) {
+          if (Array.isArray(route.transition.before)) {
+            for (let i = 0; i < route.transition.before.length; i++) {
+              if (route.transition.before[i].prop === 'alpha') {
+                isAlphaPropExists = true
+                break
+              }
+            }
+          } else {
+            if (route.transition.before.prop === 'alpha') {
+              isAlphaPropExists = true
+            }
+          }
+        }
+        // set holder alpha when alpha prop is not exists in route transition
+        if (!isAlphaPropExists) {
+          holder.set('alpha', 1)
+        }
       }
 
       this[symbols.children].push(view)


### PR DESCRIPTION
with default transition, alpha is set to zero for previous route view holder element. if preivous route is configured to keep alive then that view is cached with holder alpha set to zero

Now, if previous route has a custom transition and if it does not contain alpha related prop transition in 'before' or 'in' then holder's alpha will not get updated to 1 from zero set by previous route out transition