### PR TITLE
Fixes Router Focused Component hasFocus

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -195,7 +195,7 @@ export const navigate = async function () {
       previousFocus = Focus.get()
 
       // set focus to the view that we're routing to
-      focus ? Focus.set(focus) : Focus.set(view)
+      focus ? focus.$focus() : view.$focus()
 
       // apply before settings to holder element
       if (route.transition.before) {


### PR DESCRIPTION
Avoided directly invoking Focus.set(view/previous-focused-comp) approach which actually missing setting hasFocus flag on its component to True.

Now, Invoking $focus on target view or previously focused component from cache so that it will make sure hasFocus correctly set