### PR TITLE
Fixes show attribute issue when w & h not exists

### DIFF
--- a/src/engines/L3/element.js
+++ b/src/engines/L3/element.js
@@ -296,8 +296,8 @@ const propsTransformer = {
   set show(v) {
     if (v) {
       this.props['alpha'] = 1
-      this.props['width'] = this.raw['w'] || this.raw['width']
-      this.props['height'] = this.raw['h'] || this.raw['height']
+      this.props['width'] = this.raw['w'] || this.raw['width'] || 0
+      this.props['height'] = this.raw['h'] || this.raw['height'] || 0
     } else {
       this.props['alpha'] = 0
       this.props['width'] = 0


### PR DESCRIPTION
When width and height is not configured on an Element then observed show attribute `true` value is setting undefined as value. This will be an issue for Elements without w & h attributes

setting w & h to zero when those attributes not configured on that particular Elmeent tag