### PR TITLE
Added method for changing canvas color runtime in Blits

### DIFF
--- a/src/component/base/methods.js
+++ b/src/component/base/methods.js
@@ -21,6 +21,7 @@ import eventListeners from '../../lib/eventListeners.js'
 import { trigger } from '../../lib/reactivity/effect.js'
 import { Log } from '../../lib/log.js'
 import { removeGlobalEffects } from '../../lib/reactivity/effect.js'
+import { renderer } from '../../launch.js'
 
 export default {
   focus: {
@@ -141,6 +142,14 @@ export default {
     },
     writable: false,
     enumerable: true,
+    configurable: false,
+  },
+  $setClearColor: {
+    value: function (color) {
+      renderer.setClearColor(color)
+    },
+    writable: false,
+    enumerable: false,
     configurable: false,
   },
 }


### PR DESCRIPTION
Add method for changing canvas color runtime

**Note:** 
To make this PR work, the renderer version in Blits should be >=2.8.0