### PR TITLE
Fix background color when disabling Render-to-Texture (RTT) property

### DIFF
--- a/src/engines/L3/element.js
+++ b/src/engines/L3/element.js
@@ -251,8 +251,8 @@ const propsTransformer = {
   },
   set rtt(v) {
     this.props['rtt'] = v
-    if (v === true && this.raw['color'] === undefined) {
-      this.props['color'] = 0xffffffff
+    if (this.raw['color'] === undefined) {
+      this.props['color'] = v === true ? 0xffffffff : 0x00000000
     }
   },
   set mount(v) {


### PR DESCRIPTION
This update addresses an issue with the rtt (render-to-texture) property.

Problem: When rendering a node to a texture, the color is set to 0xffffffff to correctly display during the fragmentation step. However, if a user disables the rtt property, the background color remains white (0xffffffff), resulting in a white background on the node.

Fix: When the rtt property is disabled, the color is set to 0x00000000 (transparent alpha channel),  preventing the white background issue.