### PR TITLE
Fixes effects issues with direct obj assingment

### DIFF
--- a/src/lib/reactivity/reactive.js
+++ b/src/lib/reactivity/reactive.js
@@ -107,14 +107,16 @@ const reactiveProxy = (original, _parent = null, _key, global) => {
           : oldRawValue === rawValue
 
       if (isEqual === false) {
-        const isArrayValue = Array.isArray(value)
-        if (isArrayValue) value = getRaw(value).slice(0)
-        if (isArrayValue === false && typeof value === 'object' && target[key] !== null) {
-          Object.assign(receiver[key], value)
-          result = true
-        } else {
-          result = Reflect.set(target, key, value, receiver)
+        if (Array.isArray(value) === true) {
+          value = getRaw(value).slice(0)
+        } else if (
+          typeof value === 'object' &&
+          target[key] !== null &&
+          Array.isArray(target) === false
+        ) {
+          value = Object.assign(receiver[key], value)
         }
+        result = Reflect.set(target, key, value, receiver)
       }
 
       if (result === true && isEqual === false) {

--- a/src/lib/reactivity/reactive.js
+++ b/src/lib/reactivity/reactive.js
@@ -107,9 +107,9 @@ const reactiveProxy = (original, _parent = null, _key, global) => {
           : oldRawValue === rawValue
 
       if (isEqual === false) {
-        if (Array.isArray(value) === true) value = getRaw(value).slice(0)
-
-        if (typeof value === 'object' && target[key] !== null) {
+        const isArrayValue = Array.isArray(value)
+        if (isArrayValue) value = getRaw(value).slice(0)
+        if (isArrayValue === false && typeof value === 'object' && target[key] !== null) {
           Object.assign(receiver[key], value)
           result = true
         } else {

--- a/src/lib/reactivity/reactive.js
+++ b/src/lib/reactivity/reactive.js
@@ -108,7 +108,13 @@ const reactiveProxy = (original, _parent = null, _key, global) => {
 
       if (isEqual === false) {
         if (Array.isArray(value) === true) value = getRaw(value).slice(0)
-        result = Reflect.set(target, key, value, receiver)
+
+        if (typeof value === 'object' && target[key] !== null) {
+          Object.assign(receiver[key], value)
+          result = true
+        } else {
+          result = Reflect.set(target, key, value, receiver)
+        }
       }
 
       if (result === true && isEqual === false) {


### PR DESCRIPTION
When complete object is assiged to state variable with equal operator then effects associated with in template on assining object properties are not triggering.

Here Object.assign is working as expected but users feels this is odd to do instead of assignment operator

Moved the object.assign operation to reactive proxy set trap so that it will invoke set traps of indiviual key