### PR TITLE
Adding unknown for Index signature return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -81,7 +81,7 @@ declare module '@lightningjs/blits' {
   }
 
   export interface Input {
-    [key: string]: (event: KeyboardEvent) => void | undefined,
+    [key: string]: (event: KeyboardEvent) => void | undefined | unknown,
     /**
      * Catch all input function
      *


### PR DESCRIPTION
Input index singature Type is a function which returns void | undefined and all other custom properties Types should align with the index signature Type (including function return types as well). Here, the custom property intercept Type is a function that return value like KeyboardEvent, any, which are not part of index signature function return type so adding unknown as additional return type