### PR TITLE
Exclude index variable in forloop scope object

### DIFF
--- a/src/lib/codegenerator/generator.js
+++ b/src/lib/codegenerator/generator.js
@@ -306,8 +306,8 @@ const generateForLoopCode = function (templateObject, parent) {
     ctx.renderCode.push(`parent = ${parent}`)
   }
 
-  //If the index variable is not defined, the key attribute would not reference it.
-  if (index !== '') {
+  // If the index variable is not defined, the key attribute would not reference it.
+  if (index !== undefined) {
     const indexRegex = new RegExp(`\\$${index}(?!['\\w])`)
     const indexResult = indexRegex.exec(key)
     if (Array.isArray(indexResult)) {
@@ -329,7 +329,7 @@ const generateForLoopCode = function (templateObject, parent) {
         const ${item} = rawCollection[l]
   `)
   // push reference of index variable
-  if (index !== '') {
+  if (index !== undefined) {
     ctx.renderCode.push(`
         const ${index} = l
     `)


### PR DESCRIPTION
If index variable is not declared in :for template then avoiding adding `index` variable to scope object of for-loop so that component may contain state or prop with same index variable which will be refferenced for all elements inside for-loop template.