### PR TITLE
fix: register custom effects correctly

### DIFF
--- a/src/engines/L3/shaderLoader.js
+++ b/src/engines/L3/shaderLoader.js
@@ -7,6 +7,6 @@ export default () => {
     stage.shManager.registerShaderType(shader.name, shader.type)
   })
   Settings.get('effects', []).forEach((effect) => {
-    stage.shManager.registerShaderType(effect.name, effect.type)
+    stage.shManager.registerEffectType(effect.name, effect.type)
   })
 }


### PR DESCRIPTION
Using custom effects fails because they are being registered as shaders; register them as effects instead.