### PR TITLE
feat: add reactivity to router currentRoute object

### DIFF
--- a/src/component/base/router.js
+++ b/src/component/base/router.js
@@ -16,7 +16,7 @@
  */
 
 import symbols from '../../lib/symbols.js'
-import { to, currentRoute, navigating, back } from '../../router/router.js'
+import { to, routeState, navigating, back } from '../../router/router.js'
 
 export default {
   $router: {
@@ -24,7 +24,7 @@ export default {
       to,
       back,
       get currentRoute() {
-        return currentRoute
+        return routeState.currentRoute
       },
       get routes() {
         return this[symbols.routes]

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -22,8 +22,10 @@ import { Log } from '../lib/log.js'
 import { stage } from '../launch.js'
 import Focus from '../focus.js'
 import Announcer from '../announcer/announcer.js'
+import { reactive } from '../lib/reactivity/reactive.js'
+import Settings from '../settings.js'
 
-export let currentRoute
+export const routeState = reactive({ currentRoute: null }, Settings.get('ReactivityMode'), true)
 export let navigating = false
 
 const cacheMap = new WeakMap()
@@ -107,7 +109,7 @@ export const matchHash = (path, routes = []) => {
     if (!matchingRoute.data) {
       matchingRoute.data = {}
     }
-    currentRoute = matchingRoute
+    routeState.currentRoute = matchingRoute
   }
 
   return matchingRoute
@@ -116,7 +118,7 @@ export const matchHash = (path, routes = []) => {
 export const navigate = async function () {
   navigating = true
   if (this.parent[symbols.routes]) {
-    const previousRoute = currentRoute
+    const previousRoute = routeState.currentRoute
     const { hash, queryParams } = getHash()
     let route = matchHash(hash, this.parent[symbols.routes])
     let beforeHookOutput
@@ -125,7 +127,7 @@ export const navigate = async function () {
         if (route.hooks.before) {
           beforeHookOutput = await route.hooks.before.call(this.parent, route, previousRoute)
           if (isString(beforeHookOutput)) {
-            currentRoute = previousRoute
+            routeState.currentRoute = previousRoute
             to(beforeHookOutput)
             return
           }


### PR DESCRIPTION
#### What does this PR do?
This PR adds reactivity to the `currentRoute` property of the route object. Right now when the current route changes there is no way to know what it has changed to inside the app. This PR allows us to watch the `$router.currentRoute` object and react to the changes that occurs.