### PR TITLE
Revert "feat: add reactivity to router currentRoute object"

### DIFF
--- a/src/component/base/router.js
+++ b/src/component/base/router.js
@@ -16,7 +16,7 @@
  */
 
 import symbols from '../../lib/symbols.js'
-import { to, routeState, navigating, back } from '../../router/router.js'
+import { to, currentRoute, navigating, back } from '../../router/router.js'
 
 export default {
   $router: {
@@ -24,7 +24,7 @@ export default {
       to,
       back,
       get currentRoute() {
-        return routeState.currentRoute
+        return currentRoute
       },
       get routes() {
         return this[symbols.routes]

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -22,10 +22,8 @@ import { Log } from '../lib/log.js'
 import { stage } from '../launch.js'
 import Focus from '../focus.js'
 import Announcer from '../announcer/announcer.js'
-import { reactive } from '../lib/reactivity/reactive.js'
-import Settings from '../settings.js'
 
-export const routeState = reactive({ currentRoute: null }, Settings.get('ReactivityMode'), true)
+export let currentRoute
 export let navigating = false
 
 const cacheMap = new WeakMap()
@@ -109,7 +107,7 @@ export const matchHash = (path, routes = []) => {
     if (!matchingRoute.data) {
       matchingRoute.data = {}
     }
-    routeState.currentRoute = matchingRoute
+    currentRoute = matchingRoute
   }
 
   return matchingRoute
@@ -118,7 +116,7 @@ export const matchHash = (path, routes = []) => {
 export const navigate = async function () {
   navigating = true
   if (this.parent[symbols.routes]) {
-    const previousRoute = routeState.currentRoute
+    const previousRoute = currentRoute
     const { hash, queryParams } = getHash()
     let route = matchHash(hash, this.parent[symbols.routes])
     let beforeHookOutput
@@ -127,7 +125,7 @@ export const navigate = async function () {
         if (route.hooks.before) {
           beforeHookOutput = await route.hooks.before.call(this.parent, route, previousRoute)
           if (isString(beforeHookOutput)) {
-            routeState.currentRoute = previousRoute
+            currentRoute = previousRoute
             to(beforeHookOutput)
             return
           }


### PR DESCRIPTION
Reverts lightning-js/blits#269

After some testing is appears this change is giving some issues with back navigation. Also there are some performance concerns with making the entire route reactive by wrapping it in a Proxy.

Reverting this implementation for now, while we rethink the best way to do reactive changes in an App based on route change.