### PR TITLE
feat: add style prop support to element for passing styles as an object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@lightningjs/blits",
-      "version": "1.19.0",
+      "version": "1.19.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@lightningjs/msdf-generator": "^1.1.1",

--- a/src/engines/L3/element.js
+++ b/src/engines/L3/element.js
@@ -171,6 +171,47 @@ const colorMap = {
 
 let textDefaults = null
 
+const AvailableProps = [
+  'parent',
+  'rotation',
+  'w',
+  'width',
+  'h',
+  'height',
+  'x',
+  'y',
+  'z',
+  'zIndex',
+  'color',
+  'style',
+  'src',
+  'texture',
+  'fit',
+  'rtt',
+  'mount',
+  'pivot',
+  'scale',
+  'show',
+  'alpha',
+  'shader',
+  'effects',
+  'clipping',
+  'overflow',
+  'font',
+  'size',
+  'wordwrap',
+  'maxwidth',
+  'maxheight',
+  'contain',
+  'maxlines',
+  'textoverflow',
+  'letterspacing',
+  'lineheight',
+  'align',
+  'content',
+  'placement',
+]
+
 const propsTransformer = {
   set parent(v) {
     this.props['parent'] = v === 'root' ? renderer.root : v.node
@@ -425,6 +466,25 @@ const propsTransformer = {
     if (typeof v === 'object' || (isObjectString(v) === true && (v = parseToObject(v)))) {
       this.props['data'] = v
     }
+  },
+  set style(v) {
+    if (typeof v !== 'object') {
+      if (isObjectString(v) === true) {
+        v = parseToObject(v)
+      } else {
+        console.warn('Invalid style format: Expected an object or a valid object-like string.')
+        return
+      }
+    }
+
+    // Apply valid style properties
+    Object.entries(v).forEach(([key, value]) => {
+      if (AvailableProps.includes(key)) {
+        this[key] = value
+      } else {
+        console.warn(`"${key}" is not a valid style property.`)
+      }
+    })
   },
 }
 


### PR DESCRIPTION
**Description**

This PR introduces support for the style prop in the Element component, allowing styles to be passed as an object. This enhances flexibility by enabling dynamic style updates based on component state or props.

**Changes Introduced**
	•	Added the style prop to <Element> to support object-based styling.
	•	Updated the Box component example to demonstrate passing styles dynamically using elementStyle.

**Code Example:**

```
const Box = Blits.Component('CustomHome', {
  components: {},
  template: `
    <Element
      w="150"
      h="150"
      color="#eeaabb"
      :scale="$focused ? 1.3 : 1"
      color="{top: 'red', right:'white', left: 'black', bottom: 'blue'}"
      style="$elementStyle"
    >
      <Text content="$item.title" :textStyle="{fontSize: 20, textColor: 0xffffff}" />
    </Element>`,
  props: ['index', 'item', 'focused'],
  state() {
    return {
      elementStyle: { a: 1, b: 2, c: 3, width: 120 }
    };
  },
});
```