### PR TITLE
Disallows for loop in a root-level template tag

### DIFF
--- a/src/lib/templateparser/parser.js
+++ b/src/lib/templateparser/parser.js
@@ -239,6 +239,7 @@ export default (template = '', componentName, parentComponent, filePath = null) 
     #2: There must be exactly one top-level element (an element at level 0). This element may either be a self-closing
         element or an opening tag followed by a closing tag. If more than one top-level element is encountered, an error
         should be thrown.
+        But the top-level element can not have :for attribute.
   */
   const format = (parsedData) => {
     let stack = []
@@ -253,6 +254,10 @@ export default (template = '', componentName, parentComponent, filePath = null) 
       if (element[symbols.level] === 0 && element[symbols.type] !== 'closing') {
         if (rootElementDefined) {
           throw TemplateStructureError('MultipleTopLevelTags', element)
+        }
+        // Check for :for attribute on root level element
+        if (element[':for'] !== undefined) {
+          throw TemplateStructureError('ForAttributeOnRootElement', element)
         }
         rootElementDefined = true
       }

--- a/src/lib/templateparser/parser.test.js
+++ b/src/lib/templateparser/parser.test.js
@@ -1388,3 +1388,24 @@ test('Parse template with color and effects attributes and parsing should conver
   )
   assert.end()
 })
+
+test('Parse template with :for attribute on root element and parsing should fail', (assert) => {
+  const template = `
+  <Element :for="item in $items">
+    <Text value="$item.name" />
+  </Element>
+  `
+
+  try {
+    parser(template)
+    assert.fail('Parser should throw TemplateStructureError:ForAttributeOnRootElement')
+  } catch (error) {
+    assert.equal(error.name, 'TemplateStructureError', 'Parser should throw TemplateStructureError')
+    assert.ok(
+      error.message.startsWith('ForAttributeOnRootElement'),
+      'Parser should throw TemplateStructureError:ForAttributeOnRootElement'
+    )
+  }
+
+  assert.end()
+})

--- a/src/lib/templateparser/parser.test.js
+++ b/src/lib/templateparser/parser.test.js
@@ -1392,7 +1392,7 @@ test('Parse template with color and effects attributes and parsing should conver
 test('Parse template with :for attribute on root element and parsing should fail', (assert) => {
   const template = `
   <Element :for="item in $items">
-    <Text value="$item.name" />
+    <Text content="$item.name" />
   </Element>
   `
 


### PR DESCRIPTION
A template structure error is thrown when a for loop is used in a root-level template tag.

fixes #288 