### PR TITLE
Fix/router history and state object update

### DIFF
--- a/src/lib/reactivity/reactive.js
+++ b/src/lib/reactivity/reactive.js
@@ -101,10 +101,16 @@ const reactiveProxy = (original, _parent = null, _key, global) => {
       const rawValue = getRaw(value)
 
       let result = true
-      const isEqual =
-        Array.isArray(rawValue) === true
-          ? deepEqualArray(oldRawValue, rawValue)
-          : oldRawValue === rawValue
+      let isEqual = false
+
+      // We need to check that the oldRawValue is also undefined before we do the deep equal check
+      if (Array.isArray(rawValue) === true && Array.isArray(oldRawValue) === true) {
+        isEqual = deepEqualArray(oldRawValue, rawValue)
+      } else if (oldRawValue === rawValue) {
+        isEqual = true
+      } else {
+        isEqual = false
+      }
 
       if (isEqual === false) {
         if (typeof value === 'object') {

--- a/src/lib/reactivity/reactive.js
+++ b/src/lib/reactivity/reactive.js
@@ -108,8 +108,6 @@ const reactiveProxy = (original, _parent = null, _key, global) => {
         isEqual = deepEqualArray(oldRawValue, rawValue)
       } else if (oldRawValue === rawValue) {
         isEqual = true
-      } else {
-        isEqual = false
       }
 
       if (isEqual === false) {

--- a/src/lib/reactivity/reactive.js
+++ b/src/lib/reactivity/reactive.js
@@ -103,7 +103,7 @@ const reactiveProxy = (original, _parent = null, _key, global) => {
       let result = true
       let isEqual = false
 
-      // We need to check that the oldRawValue is also undefined before we do the deep equal check
+      // We need to check that the oldRawValue is also an array before we do the deep equal check
       if (Array.isArray(rawValue) === true && Array.isArray(oldRawValue) === true) {
         isEqual = deepEqualArray(oldRawValue, rawValue)
       } else if (oldRawValue === rawValue) {

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -177,16 +177,20 @@ export const navigate = async function () {
           queryParamsData[queryParamsEntries[i][0]] = queryParamsEntries[i][1]
         }
 
-        // merge props with potential route params, navigation data and route data to be injected into the component instance
-        const props = {
-          ...this[symbols.props],
-          ...route.params,
+        const routeData = {
           ...navigationData,
           ...route.data,
           ...queryParamsData,
         }
 
-        state.data = route.data
+        // merge props with potential route params, navigation data and route data to be injected into the component instance
+        const props = {
+          ...this[symbols.props],
+          ...route.params,
+          ...routeData,
+        }
+
+        state.data = routeData
 
         view = await route.component({ props }, holder, this)
         if (view[Symbol.toStringTag] === 'Module') {

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -343,7 +343,7 @@ const setOrAnimate = (node, transition, shouldAnimate = true) => {
 export const to = (location, data = {}, options = {}, queryParams = null) => {
   navigationData = data
   overrideOptions = options
-  let search
+  let search = ''
 
   if (queryParams) {
     search = new URLSearchParams(queryParams).toString()

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -340,14 +340,16 @@ const setOrAnimate = (node, transition, shouldAnimate = true) => {
   })
 }
 
-export const to = (location, data = {}, options = {}, queryParams = {}) => {
+export const to = (location, data = {}, options = {}, queryParams = null) => {
   navigationData = data
   overrideOptions = options
-  let search = new URLSearchParams(queryParams).toString()
+  let search
 
-  if (search.trim().length > 0) {
+  if (queryParams) {
+    search = new URLSearchParams(queryParams).toString()
     search = `?${search}`
   }
+
   window.location.hash = `#${location}${search}`
 }
 

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -28,8 +28,8 @@ export let currentRoute
 export const state = reactive({
   path: '',
   navigating: false,
-  data: {},
-  params: {},
+  data: null,
+  params: null,
   hash: '',
 })
 
@@ -62,7 +62,7 @@ const isObject = (v) => typeof v === 'object' && v !== null
 
 const isString = (v) => typeof v === 'string'
 
-export const matchHash = (path, routes = [], hash = null) => {
+export const matchHash = (path, routes = []) => {
   // remove trailing slashes
   const originalPath = path
   path = normalizePath(path)
@@ -115,10 +115,6 @@ export const matchHash = (path, routes = [], hash = null) => {
     if (!matchingRoute.data) {
       matchingRoute.data = {}
     }
-
-    if (hash !== null) {
-      matchingRoute.hash = hash
-    }
   }
 
   return matchingRoute
@@ -129,7 +125,13 @@ export const navigate = async function () {
   if (this.parent[symbols.routes]) {
     let previousRoute = currentRoute ? Object.assign({}, currentRoute) : undefined
     const { hash, path, queryParams } = getHash()
-    let route = matchHash(path, this.parent[symbols.routes], hash)
+    let route = matchHash(path, this.parent[symbols.routes])
+
+    // Adding the location hash to the route if it exists.
+    if (hash !== null) {
+      route.hash = hash
+    }
+
     currentRoute = route
     let beforeHookOutput
     if (route) {
@@ -184,7 +186,7 @@ export const navigate = async function () {
           ...queryParamsData,
         }
 
-        state.data = props
+        state.data = route.data
 
         view = await route.component({ props }, holder, this)
         if (view[Symbol.toStringTag] === 'Module') {

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -352,9 +352,8 @@ export const back = function () {
   if (route && currentRoute !== route) {
     // set indicator that we are navigating back (to prevent adding page to history stack)
     navigatingBack = true
-    let targetRoutePath = route.hash
 
-    to(targetRoutePath, route.data, route.options)
+    to(route.hash, route.data, route.options)
     return true
   }
 

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -30,7 +30,7 @@ export const state = reactive({
   navigating: false,
   queryParams: {},
   params: {},
-  rawPath: null,
+  hash: null,
 })
 
 const cacheMap = new WeakMap()

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -162,6 +162,7 @@ export const navigate = async function () {
       }
 
       let holder
+      let routeData
       let { view, focus } = cacheMap.get(route) || {}
 
       if (!view) {
@@ -177,7 +178,7 @@ export const navigate = async function () {
           queryParamsData[queryParamsEntries[i][0]] = queryParamsEntries[i][1]
         }
 
-        const routeData = {
+        routeData = {
           ...navigationData,
           ...route.data,
           ...queryParamsData,
@@ -189,8 +190,6 @@ export const navigate = async function () {
           ...route.params,
           ...routeData,
         }
-
-        state.data = routeData
 
         view = await route.component({ props }, holder, this)
         if (view[Symbol.toStringTag] === 'Module') {
@@ -262,6 +261,7 @@ export const navigate = async function () {
       state.path = route.path
       state.params = route.params
       state.hash = hash
+      state.data = routeData
 
       // apply in transition
       if (route.transition.in) {

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -25,7 +25,13 @@ import Focus from '../focus.js'
 import Announcer from '../announcer/announcer.js'
 
 export let currentRoute
-export const state = reactive({ path: null, navigating: false })
+export const state = reactive({
+  path: null,
+  navigating: false,
+  queryParams: {},
+  params: {},
+  rawPath: null,
+})
 
 const cacheMap = new WeakMap()
 const history = []
@@ -249,7 +255,10 @@ export const navigate = async function () {
         previousRoute = undefined
       }
 
-      state.path = route.path
+      state.rawPath = route.path
+      state.queryParams = route.queryParams
+      state.params = route.params
+      state.path = hash
 
       // apply in transition
       if (route.transition.in) {


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the issue where the back navigation does not work as expected when the `currentRoute` is a dynamic route and the currentRoute object assigned to the `previousRoute` value is updated by reference when `currentRoute` changes. 

In addition to this fix, the route can now handle the back navigation even when the query parameters change.

The PR also adds more properties to the `$router.state` object, such as `queryParams, params, ` and updates the value referenced in the path property to be the correct hash path, even for dynamic routes.