### PR TITLE
fix: keep alive no longer working on router back

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -314,9 +314,9 @@ const removeView = async (route, view, transition) => {
   }
 
   // cache the page when it's as 'keepAlive' instead of destroying
-  if (route.options && route.options.keepAlive === true) {
+  if (route.options && route.options.keepAlive === true && navigatingBack === false) {
     cacheMap.set(route.hash, { view: view, focus: previousFocus })
-  } else if (navigatingBack === true) {
+  } else if (cacheMap.has(route.hash) === true && navigatingBack === true) {
     cacheMap.delete(route.hash)
   }
 

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -316,7 +316,9 @@ const removeView = async (route, view, transition) => {
   // cache the page when it's as 'keepAlive' instead of destroying
   if (route.options && route.options.keepAlive === true && navigatingBack === false) {
     cacheMap.set(route.hash, { view: view, focus: previousFocus })
-  } else if (cacheMap.has(route.hash) === true && navigatingBack === true) {
+  } else if (navigatingBack === true) {
+    // remove the previous route from the cache when navigating back
+    // cacheMap.delete will not throw an error if the route is not in the cache
     cacheMap.delete(route.hash)
   }
 

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -316,7 +316,7 @@ const removeView = async (route, view, transition) => {
   // cache the page when it's as 'keepAlive' instead of destroying
   if (route.options && route.options.keepAlive === true) {
     cacheMap.set(route.hash, { view: view, focus: previousFocus })
-  } else if (cacheMap.has(route.hash) && route.options.keepAlive === false) {
+  } else if (navigatingBack === true) {
     cacheMap.delete(route.hash)
   }
 

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -33,6 +33,8 @@ export const state = reactive({
   hash: '',
 })
 
+// Changed from WeakMap to Map to allow for caching of views by the url hash.
+// We are manually doing the cleanup of the cache when the route is not marked as keepAlive.
 const cacheMap = new Map()
 const history = []
 

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -33,7 +33,7 @@ export const state = reactive({
   hash: '',
 })
 
-const cacheMap = new WeakMap()
+const cacheMap = new Map()
 const history = []
 
 let overrideOptions = {}
@@ -163,7 +163,7 @@ export const navigate = async function () {
 
       let holder
       let routeData
-      let { view, focus } = cacheMap.get(route) || {}
+      let { view, focus } = cacheMap.get(route.hash) || {}
 
       if (!view) {
         // create a holder element for the new view
@@ -313,8 +313,12 @@ const removeView = async (route, view, transition) => {
 
   // cache the page when it's as 'keepAlive' instead of destroying
   if (route.options && route.options.keepAlive === true) {
-    cacheMap.set(route, { view: view, focus: previousFocus })
-  } else {
+    cacheMap.set(route.hash, { view: view, focus: previousFocus })
+  } else if (cacheMap.has(route.hash) && route.options.keepAlive === false) {
+    cacheMap.delete(route.hash)
+  }
+
+  if (route.options && route.options.keepAlive === false) {
     view.destroy()
     view = null
   }


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the issue with the route `keepAlive` option not working as expected when the `$router.back` method has been triggered.

