### PR TITLE
Destoy View on Navigating Back with KeepAlive Set to True

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -328,9 +328,9 @@ const removeView = async (route, view, transition) => {
   }
 
   // cache the page when it's as 'keepAlive' instead of destroying
-  if (route.options && route.options.keepAlive === true && navigatingBack === false) {
+  if (navigatingBack === false && route.options && route.options.keepAlive === true) {
     cacheMap.set(route.hash, { view: view, focus: previousFocus })
-  } else if (navigatingBack === true) {
+  } else if (navigatingBack === true && route.options && route.options.keepAlive !== true) {
     // remove the previous route from the cache when navigating back
     // cacheMap.delete will not throw an error if the route is not in the cache
     cacheMap.delete(route.hash)

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -330,13 +330,17 @@ const removeView = async (route, view, transition) => {
   // cache the page when it's as 'keepAlive' instead of destroying
   if (navigatingBack === false && route.options && route.options.keepAlive === true) {
     cacheMap.set(route.hash, { view: view, focus: previousFocus })
-  } else if (navigatingBack === true && route.options && route.options.keepAlive !== true) {
+  } else if (navigatingBack === true) {
     // remove the previous route from the cache when navigating back
     // cacheMap.delete will not throw an error if the route is not in the cache
     cacheMap.delete(route.hash)
   }
-
-  if (route.options && route.options.keepAlive !== true) {
+  /* Destroy the view in the following cases:
+   * 1. Navigating forward, and the previous route is not configured with "keep alive" set to true.
+   * 2. Navigating back, and the previous route is configured with "keep alive" set to true.
+   * 3. Navigating back, and the previous route is not configured with "keep alive" set to true.
+   */
+  if (route.options && (route.options.keepAlive !== true || navigatingBack === true)) {
     view.destroy()
     view = null
   }


### PR DESCRIPTION
Fixes not removing router view, which configured as keep alive true, from cache map.