### PR TITLE
Release 1.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v1.23.0
+
+_13 mar 2025_
+
+- Added support for beforeEach router hook
+- Added warning when variables used in the template are not declared on the component scope (only during dev)
+- Added vite plugin that ensures reactivity is setup properly for all state variables in a computed prop
+- Fixed keepAlive functionality in the router on back navigation
+- Fixed various test cases
+- Added useful base methods to the this context of plugins
+- Added workflow to execute test cases for PRs
+- Updated L3 renderer dependency to v2.13.2
+- Fixed various typos in the documentation
+- Fixed reactivity issue when value is set to `null`
+
 ## v1.22.0
 
 _3 mar 2025_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.23.1
+
+_17 mar 2025_
+
+- Fixed issue in vite plugin that ensures reacitivity setup in computed props when code block has a comment
+- Fixed warnings for non-declared variables in template when they refer to plugins (i.e. `$$apState.foo`)
+
 ## v1.23.0
 
 _13 mar 2025_

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lightningjs/blits",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lightningjs/blits",
-      "version": "1.23.0",
+      "version": "1.23.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@lightningjs/msdf-generator": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lightningjs/blits",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lightningjs/blits",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@lightningjs/msdf-generator": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightningjs/blits",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "Blits: The Lightning 3 App Development Framework",
   "bin": "bin/index.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightningjs/blits",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "Blits: The Lightning 3 App Development Framework",
   "bin": "bin/index.js",
   "exports": {

--- a/src/lib/reactivity/effect.js
+++ b/src/lib/reactivity/effect.js
@@ -45,7 +45,7 @@ export const removeGlobalEffects = (effectsToRemove) => {
 }
 
 export const track = (target, key, global = false) => {
-  if (currentEffect) {
+  if (currentEffect !== null) {
     if (paused) {
       return
     }
@@ -55,12 +55,12 @@ export const track = (target, key, global = false) => {
     } else if (currentKey !== null && key !== currentKey) return
 
     let effectsMap = objectMap.get(target)
-    if (!effectsMap) {
+    if (effectsMap === undefined) {
       effectsMap = new Map()
       objectMap.set(target, effectsMap)
     }
     let effects = effectsMap.get(key)
-    if (!effects) {
+    if (effects === undefined) {
       effects = new Set()
       effectsMap.set(key, effects)
     }
@@ -73,11 +73,11 @@ export const track = (target, key, global = false) => {
 export const trigger = (target, key, force = false) => {
   if (paused === true) return
   const effectsMap = objectMap.get(target)
-  if (!effectsMap) {
+  if (effectsMap === undefined) {
     return
   }
   const effects = effectsMap.get(key)
-  if (effects) {
+  if (effects !== undefined) {
     for (let effect of effects) {
       effect(force)
     }

--- a/src/lib/reactivity/reactive.js
+++ b/src/lib/reactivity/reactive.js
@@ -115,6 +115,7 @@ const reactiveProxy = (original, _parent = null, _key, global) => {
           if (Array.isArray(value) === true) {
             value = getRaw(value).slice(0)
           } else if (
+            value !== null &&
             target[key] !== null &&
             target[key] !== undefined &&
             Array.isArray(target) === false &&


### PR DESCRIPTION
- Fixed issue in vite plugin that ensures reacitivity setup in computed props when code block has a comment
- Fixed warnings for non-declared variables in template when they refer to plugins (i.e. `$$apState.foo`)
