### PR TITLE
Updated refferencing cached route view on navigate

### DIFF
--- a/src/router/ViewManager.js
+++ b/src/router/ViewManager.js
@@ -1,0 +1,38 @@
+export default class ViewManager {
+  constructor() {
+    // Initializes the ViewManager with a Map to store page instances
+    // and a counter to keep track of the current entry.
+    this.store = new Map()
+    this.counter = 0
+    this.createEntry()
+  }
+
+  createEntry() {
+    // Creates a new entry in the store by incrementing the counter
+    // and initializing the entry with a null value.
+    this.counter++
+    this.store.set(this.counter, null)
+  }
+
+  setView(obj) {
+    // Sets the view object for the current entry in the store
+    this.store.set(this.counter, obj)
+  }
+
+  getView() {
+    // Retrieves the view object for the current entry in the store.
+    return this.store.get(this.counter)
+  }
+
+  removeView() {
+    // Removes the current entry from the store by deleting the entry
+    // associated with the current counter and then decrements the counter.
+    this.store.delete(this.counter)
+    this.counter--
+  }
+
+  size() {
+    // Returns the current number of entries in the store
+    return this.counter
+  }
+}

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -179,7 +179,7 @@ export const navigate = async function () {
 
       let holder
       let routeData
-      let { view, focus } = cacheMap.get(route.hash) || {}
+      let { view, focus } = navigatingBack === true ? cacheMap.get(route.hash) || {} : {}
 
       if (!view) {
         // create a holder element for the new view
@@ -330,17 +330,16 @@ const removeView = async (route, view, transition) => {
   // cache the page when it's as 'keepAlive' instead of destroying
   if (navigatingBack === false && route.options && route.options.keepAlive === true) {
     cacheMap.set(route.hash, { view: view, focus: previousFocus })
-  } else if (navigatingBack === true) {
-    // remove the previous route from the cache when navigating back
+  } else if (navigatingBack === true && route.options && route.options.keepAlive !== true) {
+    // remove the previous route from the cache when navigating back & route is not configure with keep alive
     // cacheMap.delete will not throw an error if the route is not in the cache
     cacheMap.delete(route.hash)
   }
   /* Destroy the view in the following cases:
    * 1. Navigating forward, and the previous route is not configured with "keep alive" set to true.
-   * 2. Navigating back, and the previous route is configured with "keep alive" set to true.
-   * 3. Navigating back, and the previous route is not configured with "keep alive" set to true.
+   * 2. Navigating back, and the previous route is not configured with "keep alive" set to true.
    */
-  if (route.options && (route.options.keepAlive !== true || navigatingBack === true)) {
+  if (route.options && route.options.keepAlive !== true) {
     view.destroy()
     view = null
   }

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -177,23 +177,23 @@ export const navigate = async function () {
       if (typeof route.transition === 'function') {
         route.transition = route.transition(previousRoute, route)
       }
+      let viewManager = cacheMap.get(route.hash)
 
       if (navigatingBack === false && route.options && route.options.keepAlive === true) {
         // If ViewManager exists for the route hash, add a new entry to it.
-        if (cacheMap.has(route.hash) === true) {
-          cacheMap.get(route.hash).createEntry()
+        if (viewManager !== undefined) {
+          viewManager.createEntry()
         } else {
           // Create a ViewManager instance for the route hash if it doesn't exist in cacheMap.
-          cacheMap.set(route.hash, new ViewManager())
+          viewManager = new ViewManager()
+          cacheMap.set(route.hash, viewManager)
         }
       }
 
       let holder
       let routeData
       let { view, focus } =
-        navigatingBack === true && cacheMap.has(route.hash)
-          ? cacheMap.get(route.hash).getView() || {}
-          : {}
+        (navigatingBack === true && viewManager !== undefined && viewManager.getView()) || {}
 
       if (!view) {
         // create a holder element for the new view


### PR DESCRIPTION
1. On navigating using $route.to method, always create new instance of component eventhough its already cached by keepAlive
2. Not removing keepAlive pages from cache on back navigation
3. Destroying non keep alive pages on route change