### PR TITLE
Removed usage of KeyboardEvent.key

### DIFF
--- a/docs/components/user_input.md
+++ b/docs/components/user_input.md
@@ -137,9 +137,9 @@ But it's possible that the keycodes and mapping of your target device are slight
 
 In Blits, you can easily configure the key mapping to match your needs. In the `src/index.js` file where we instantiate the App via the `Blits.Launch` function, we can add an extra key, called `keymap`, to the _settings object_.
 
-The `keymap` should contain an object literal, where you map a `key` or `keyCode` (from the `KeyboardEvent`) to an event name that you can use in your Components.
+The `keymap` should contain an object literal, where you map a `keyCode` (from the `KeyboardEvent`) to an event name that you can use in your Components.
 
-> You can use a site like [keyjs.dev](https://keyjs.dev/) to find the appropriate key and keyCode for your device
+> You can use [this page](https://blits-demo.lightningjs.io/#/examples/keycodes) in the Blits Example app to find the appropriate keyCode for your device
 
 ```js
 // src/index.js
@@ -148,14 +148,11 @@ Blits.Launch(App, 'app', {
   h: 1080,
   //...
   keymap: {
-    // switch left and right using the key
-    ArrowLeft: 'right',
-    ArrowRight: 'left',
-    // switch up and down using the keyCode
+    // switch up and down
     38: 'down',
     40: 'up',
     // register new handlers
-    '.': 'dot', // dot() can now be used in the input object
+    190: 'dot', // dot() can now be used in the input object
     // key code for letter 's'
     83: 'search' // search() can now be used in the input object
   }

--- a/src/application.js
+++ b/src/application.js
@@ -24,14 +24,6 @@ import { DEFAULT_HOLD_TIMEOUT_MS } from './constants.js'
 
 const Application = (config) => {
   const defaultKeyMap = {
-    ArrowLeft: 'left',
-    ArrowRight: 'right',
-    ArrowUp: 'up',
-    ArrowDown: 'down',
-    Enter: 'enter',
-    ' ': 'space',
-    Backspace: 'back',
-    Escape: 'escape',
     37: 'left',
     39: 'right',
     38: 'up',
@@ -57,7 +49,7 @@ const Application = (config) => {
     const keyMap = { ...defaultKeyMap, ...Settings.get('keymap', {}) }
 
     keyDownHandler = async (e) => {
-      const key = keyMap[e.key] || keyMap[e.keyCode] || e.key || e.keyCode
+      const key = keyMap[e.keyCode] || e.keyCode
       // intercept key press if specified in main Application component
       if (
         this[symbols.inputEvents] !== undefined &&


### PR DESCRIPTION
Currently Blits uses a mix of `KeyboardEvent.key` and `KeyboardEvent.keyCode` to map key presses. The original rationale for this choice was driven by the fact that `key` is deprecated (and discouraged to be used) in favour of `keyCode`, but `keyCode` is only available since Chrome 51.

Relying on both APIs can lead to weird situations where pressing `8` maps to a `backspace` and there's no way to actually receive the number `8` as input value.

In practice `KeyboardEvent.key` is the more reliable API and still available in all modern browsers.

This PR removes `keyCode` entirely.