### PR TITLE
Fix/async request routing back

### DIFF
--- a/src/component/base/methods.js
+++ b/src/component/base/methods.js
@@ -59,6 +59,7 @@ export default {
       deleteChildren(this[symbols.children])
       removeGlobalEffects(this[symbols.effects])
       Log.debug(`Destroyed component ${this.componentId}`)
+      this[symbols.state] = {}
     },
     writable: false,
     enumerable: true,

--- a/src/component/base/methods.js
+++ b/src/component/base/methods.js
@@ -60,6 +60,7 @@ export default {
       removeGlobalEffects(this[symbols.effects])
       Log.debug(`Destroyed component ${this.componentId}`)
       this[symbols.state] = {}
+      this[symbols.props] = {}
     },
     writable: false,
     enumerable: true,


### PR DESCRIPTION
Fix to address weird artefacts when routes are change during an async data request, as reported here: https://github.com/lightning-js/blits-example-app/issues/53