### PR TITLE
Added import of renderer package.json to make sure the correct versio…

### DIFF
--- a/src/launch.js
+++ b/src/launch.js
@@ -19,7 +19,7 @@ import Settings from './settings.js'
 import { initLog, Log } from './lib/log.js'
 import engine from './engine.js'
 import blitsPackageInfo from '../package.json' assert { type: 'json' }
-import rendererPackageInfo from '../node_modules/@lightningjs/renderer/package.json' assert { type: 'json' }
+import rendererPackageInfo from '../../renderer/package.json' assert { type: 'json' }
 
 export let renderer = {}
 export const stage = {}

--- a/src/launch.js
+++ b/src/launch.js
@@ -18,7 +18,8 @@
 import Settings from './settings.js'
 import { initLog, Log } from './lib/log.js'
 import engine from './engine.js'
-import packageInfo from '../package.json' assert { type: 'json' }
+import blitsPackageInfo from '../package.json' assert { type: 'json' }
+import rendererPackageInfo from '../node_modules/@lightningjs/renderer/package.json' assert { type: 'json' }
 
 export let renderer = {}
 export const stage = {}
@@ -27,8 +28,8 @@ export default (App, target, settings) => {
   Settings.set(settings)
 
   initLog()
-  Log.info('Blits Version ', packageInfo.version)
-  Log.info('Renderer Version ', packageInfo.dependencies['@lightningjs/renderer'])
+  Log.info('Blits Version ', blitsPackageInfo.version)
+  Log.info('Renderer Version ', rendererPackageInfo.version)
 
   stage.element = engine.Element
 


### PR DESCRIPTION
Before we were retrieving the renderer version from the blits package.json which wouldn't always correspond with the actual version (especially when testing versions locally)