### PR TITLE
Replaced config key on component instance with a symbol 

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -272,7 +272,7 @@ const Component = (name = required('name'), config = required('config')) => {
 
   // store the config on the factory, in order to access the config
   // during the code generation step
-  factory.config = config
+  factory[Symbol.for('config')] = config
 
   // To determine whether dynamic component is actual Blits component or not
   factory[symbols.isComponent] = true

--- a/src/component/base/utils.js
+++ b/src/component/base/utils.js
@@ -45,7 +45,8 @@ export default {
               if (Object.getPrototypeOf(child) === Object.prototype) {
                 return Object.values(child).map((c) => {
                   // ugly hack .. but the point is to reference the right component
-                  c.forComponent = c.config && c.config.parent.component
+                  c.forComponent =
+                    c[Symbol.for('config')] && c[Symbol.for('config')].parent.component
                   return c
                 })
               }

--- a/src/lib/codegenerator/generator.js
+++ b/src/lib/codegenerator/generator.js
@@ -191,9 +191,9 @@ const generateElementCode = function (
     renderCode.push(`
     const skip${counter} = []
     if(typeof cmp${counter} !== 'undefined') {
-      for(let key in cmp${counter}.config.props) {
-        delete elementConfig${counter}[cmp${counter}.config.props[key]]
-        skip${counter}.push(cmp${counter}.config.props[key])
+      for(let key in cmp${counter}[Symbol.for('config')].props) {
+        delete elementConfig${counter}[cmp${counter}[Symbol.for('config')].props[key]]
+        skip${counter}.push(cmp${counter}[Symbol.for('config')].props[key])
       }
     }
     `)

--- a/src/lib/symbols.js
+++ b/src/lib/symbols.js
@@ -37,6 +37,8 @@ export default {
   children: Symbol.for('children'),
   // Symbol 'components' utilized within generated code
   components: Symbol.for('components'),
+  // Symbol 'config' utilized within generated code
+  config: Symbol.for('config'),
   // Symbol 'isSlot' utilized within generated code
   isSlot: Symbol.for('isSlot'),
   // Symbol 'props' utilized within generated code


### PR DESCRIPTION
When using config key directly there is a chance of a naming collision. Since config is intended for internal use only, moving it to a symbol