### PR TITLE
Fix/announcer when speechsynthesis not available

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ import {type ShaderEffect as RendererShaderEffect, type WebGlCoreShader, type Re
 declare module '@lightningjs/blits' {
 
 
-  export interface AnnouncerUtterance extends Promise {
+  export interface AnnouncerUtterance extends Promise<T> {
     /**
      * Removes a specific message from the announcement queue,
      * to make sure it isn't spoke out.

--- a/src/announcer/speechSynthesis.js
+++ b/src/announcer/speechSynthesis.js
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Log } from '../lib/log'
+import { Log } from '../lib/log.js'
 
 const syn = window.speechSynthesis
 

--- a/src/announcer/speechSynthesis.js
+++ b/src/announcer/speechSynthesis.js
@@ -15,6 +15,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Log } from '../lib/log'
+
 const syn = window.speechSynthesis
 
 const isAndroid = /android/i.test((window.navigator || {}).userAgent || '')
@@ -82,14 +84,21 @@ const speak = (options) => {
 
 export default {
   speak(options) {
-    if (!initialized) {
-      initialize()
+    if (syn !== undefined) {
+      if (initialized === false) {
+        initialize()
+      }
+      return speak(options)
+    } else {
+      Log.error('speechSynthesis web API not available')
+      return Promise.reject({ error: 'unavailable' })
     }
-    return speak(options)
   },
   cancel() {
-    syn.cancel()
-    clear()
+    if (syn !== undefined) {
+      syn.cancel()
+      clear()
+    }
   },
   // @todo
   // getVoices() {


### PR DESCRIPTION
Although the speech Synthesis API is available since Chrome 33, on certain devices the module is not available, which would lead to a fatal error in the current implementation.

This PR adds checks to ensure the app will launch properly even if the speech Synthesis API is nog present.