### PR TITLE
Renamed beforeAll router hook to beforeEach

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -481,7 +481,7 @@ declare module '@lightningjs/blits' {
   }
 
   export interface RouterHooks {
-    beforeEach?: (to: Route, from: Route) => string | Route | Promise<string | Route>;
+    beforeEach?: (to: Route, from: Route) => string | Route | Promise<string | Route> | void;
   }
 
   export interface RouterConfig {

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -148,8 +148,8 @@ export const navigate = async function () {
       let beforeEachResult
       if (this.parent[symbols.routerHooks]) {
         const hooks = this.parent[symbols.routerHooks]
-        if (hooks.beforeAll) {
-          beforeEachResult = await hooks.beforeAll(route, previousRoute)
+        if (hooks.beforeEach) {
+          beforeEachResult = await hooks.beforeEach(route, previousRoute)
           if (isString(beforeEachResult)) {
             to(beforeEachResult)
             return


### PR DESCRIPTION
The router hook function ended up being called beforeAll in the code, whereas I think we intended to name it beforeEach