### PR TITLE
Feat/inline text reactivity

### DIFF
--- a/src/lib/codegenerator/generator.js
+++ b/src/lib/codegenerator/generator.js
@@ -201,7 +201,7 @@ const generateElementCode = function (
       const output = parseTagContent(val, options.component)
       renderCode.push(`elementConfig${counter}['content'] = ${output}`)
 
-      const variableRegEx = /\{\{\s*[^}]*\$\S*\s*\}\}/
+      const variableRegEx = /\{\{\s*(?=[^}]*\$).+?\s*\}\}/
       // Check if the interpolation contains $ variable
       const isReactive = variableRegEx.test(val)
       if (isReactive === true) {

--- a/src/lib/codegenerator/generator.test.js
+++ b/src/lib/codegenerator/generator.test.js
@@ -2260,7 +2260,7 @@ test('Generate code for a template with inline Text', (assert) => {
         children: [
           {
             [Symbol.for('componentType')]: 'Text',
-            content: 'Hello Blits!',
+            [Symbol.for('tagContent')]: 'Hello Blits!',
           },
         ],
       },
@@ -2288,8 +2288,8 @@ test('Generate code for a template with inline Text', (assert) => {
       parent = elms[0]
       const elementConfig1 = {}
       elms[1] = this.element({ parent: parent || 'root' }, inSlot === true ? slotComponent : component)
-      elementConfig1['content'] = 'HelloBlits!'
       elementConfig1['__textnode'] = true
+      elementConfig1['content'] = 'HelloBlits!'
       elms[1].populate(elementConfig1)
       if (inSlot === true) {
         slotChildCounter -= 1
@@ -2321,7 +2321,7 @@ test('Generate code for a template with inline dynamic Text', (assert) => {
         children: [
           {
             [Symbol.for('componentType')]: 'Text',
-            content: '$myText',
+            [Symbol.for('tagContent')]: '{{$myText}}',
           },
         ],
       },
@@ -2349,8 +2349,8 @@ test('Generate code for a template with inline dynamic Text', (assert) => {
       parent = elms[0]
       const elementConfig1 = {}
       elms[1] = this.element({ parent: parent || 'root' }, inSlot === true ? slotComponent : component)
-      elementConfig1['content'] = component.myText
       elementConfig1['__textnode'] = true
+      elementConfig1['content'] = (component.myText)
       elms[1].populate(elementConfig1)
 
       if (inSlot === true) {
@@ -2369,8 +2369,8 @@ test('Generate code for a template with inline dynamic Text', (assert) => {
     'Generator should return a render function with the correct code'
   )
   assert.ok(
-    Array.isArray(actual.effects) && actual.effects.length === 0,
-    'Generator should return an empty effects array'
+    Array.isArray(actual.effects) && actual.effects.length === 1,
+    'Generator should return effects array with length 1'
   )
   assert.end()
 })
@@ -2383,7 +2383,7 @@ test('Generate code for a template with inline dynamic Text embedded in static t
         children: [
           {
             [Symbol.for('componentType')]: 'Text',
-            content: 'Hello {{$firstname}} {{$lastname}}, how are you?',
+            [Symbol.for('tagContent')]: 'Hello {{$firstname}} {{$lastname}}, how are you?',
           },
         ],
       },
@@ -2410,8 +2410,8 @@ test('Generate code for a template with inline dynamic Text embedded in static t
       parent = elms[0]
       const elementConfig1 = {}
       elms[1] = this.element({ parent: parent || 'root' }, inSlot === true ? slotComponent : component)
-      elementConfig1['content'] = 'Hello '+component.firstname+' '+component.lastname+', how are you?'
       elementConfig1['__textnode'] = true
+      elementConfig1['content'] = "Hello "+(component.firstname)+" "+(component.lastname)+", how are you?"
       elms[1].populate(elementConfig1)
 
       if(inSlot === true) {
@@ -2423,15 +2423,14 @@ test('Generate code for a template with inline dynamic Text embedded in static t
   `
 
   const actual = generator.call(scope, templateObject)
-
   assert.equal(
     normalize(actual.render.toString()),
     normalize(expectedRender),
     'Generator should return a render function with the correct code'
   )
   assert.ok(
-    Array.isArray(actual.effects) && actual.effects.length === 0,
-    'Generator should return an empty effects array'
+    Array.isArray(actual.effects) && actual.effects.length === 1,
+    'Generator should return effects array with length 1'
   )
   assert.end()
 })

--- a/src/lib/symbols.js
+++ b/src/lib/symbols.js
@@ -53,4 +53,6 @@ export default {
   effects: Symbol.for('effects'),
   // Symbol 'removeGlobalEffects' utilized within generated code
   removeGlobalEffects: Symbol.for('removeGlobalEffects'),
+  // Symbol 'removeGlobalEffects' utilized within generated code
+  tagContent: Symbol.for('tagContent'),
 }

--- a/src/lib/templateparser/parser.js
+++ b/src/lib/templateparser/parser.js
@@ -143,7 +143,7 @@ export default (template = '', componentName, parentComponent, filePath = null) 
       if (currentTag[symbols.type] === 'opening') {
         const tagContent = template.slice(cursor, template.indexOf('<', cursor))
         if (tagContent) {
-          currentTag.content = tagContent
+          currentTag[Symbol.for('tagContent')] = tagContent
           cursor += tagContent.length
         }
       }

--- a/src/lib/templateparser/parser.test.js
+++ b/src/lib/templateparser/parser.test.js
@@ -18,7 +18,7 @@
 import test from 'tape'
 import parser from './parser.js'
 import symbols from '../symbols.js'
-const { componentType } = symbols
+const { componentType, tagContent } = symbols
 import { initLog } from '../log.js'
 initLog()
 
@@ -753,7 +753,7 @@ test('Parse template with inline text between tags', (assert) => {
             x: '40',
             y: '40',
             color: '0xfb923cff',
-            content: 'Lorem ipsum',
+            [tagContent]: 'Lorem ipsum',
           },
         ],
       },
@@ -792,29 +792,89 @@ test('Parse template with multiple inline texts between different tags', (assert
             x: '40',
             y: '40',
             color: '0xfb923cff',
-            content: 'Lorem ipsum',
+            [tagContent]: 'Lorem ipsum',
           },
           {
             [componentType]: 'Element',
-            content: 'dolor sit amet',
+            [tagContent]: 'dolor sit amet',
           },
           {
             [componentType]: 'Element',
             children: [
               {
                 [componentType]: 'Text',
-                content: 'consectetur adipiscing elit',
+                [tagContent]: 'consectetur adipiscing elit',
               },
               {
                 [componentType]: 'Element',
                 children: [
                   {
                     [componentType]: 'Text',
-                    content: 'sed do eiusmod tempor',
+                    [tagContent]: 'sed do eiusmod tempor',
                   },
                 ],
               },
             ],
+          },
+        ],
+      },
+    ],
+  }
+
+  const actual = parser(template)
+
+  assert.deepEqual(actual, expected, 'Parser should return object representation of template')
+  assert.end()
+})
+
+test('Parse template with dynamic variable as inline text', (assert) => {
+  const template = `
+  <Element>
+    <Text x="90" y="200" size="32">{{$title}}</Text>
+  </Element>
+  `
+
+  const expected = {
+    children: [
+      {
+        [componentType]: 'Element',
+        children: [
+          {
+            [componentType]: 'Text',
+            x: '90',
+            y: '200',
+            size: '32',
+            [tagContent]: '{{$title}}',
+          },
+        ],
+      },
+    ],
+  }
+
+  const actual = parser(template)
+
+  assert.deepEqual(actual, expected, 'Parser should return object representation of template')
+  assert.end()
+})
+
+test('Parse template with dynamic variable and additional string as inline text', (assert) => {
+  const template = `
+  <Element>
+    <Text x="90" y="200" size="32">Welcome to Blits {{$version}}</Text>
+  </Element>
+  `
+
+  const expected = {
+    children: [
+      {
+        [componentType]: 'Element',
+        children: [
+          {
+            [componentType]: 'Text',
+            x: '90',
+            y: '200',
+            size: '32',
+            [tagContent]: 'Welcome to Blits {{$version}}',
           },
         ],
       },


### PR DESCRIPTION
1. Added support for inline text reactivity
2. Added logic to parse text interpolation `({{ }})`
3. Added new test cases to parser
4. Updated code-generator failed test cases

Created a sample playground example which points to current PR branch and demonstrate few possible inline text combinations with JS expressions from state object, Math and logical. 

https://playground.lightningjs.io/#sgqS4HeLwk9A

please add missing scenarios to capture failures at this stage :) 
