### PR TITLE
fixes PR detection issue if PR opened from a fork

### DIFF
--- a/.github/workflows/comment-lint-results.yml
+++ b/.github/workflows/comment-lint-results.yml
@@ -58,13 +58,28 @@ jobs:
         if: steps.download.outputs.result == 'true'
         id: extract
         run: |
-          mkdir -p lint-results
-          unzip -o lint-results.zip -d lint-results
+          mkdir -p extracted
+          unzip -o lint-results.zip -d extracted
 
-          if [ -f lint-results/errors.md ]; then
-            echo "LINT_ERRORS<<EOF" >> $GITHUB_ENV
-            cat lint-results/errors.md >> $GITHUB_ENV
-            echo "EOF" >> $GITHUB_ENV
+          # Read PR information
+          if [ -f extracted/pr_number.txt ]; then
+            echo "PR_NUMBER=$(cat extracted/pr_number.txt)" >> $GITHUB_ENV
+          else
+            echo "PR_NUMBER=0" >> $GITHUB_ENV
+          fi
+
+          if [ -f extracted/errors.md ] || [ -f extracted/lint-results/errors.md ]; then
+            if [ -f extracted/errors.md ]; then
+              # Handle flat structure
+              echo "LINT_ERRORS<<EOF" >> $GITHUB_ENV
+              cat extracted/errors.md >> $GITHUB_ENV
+              echo "EOF" >> $GITHUB_ENV
+            else
+              # Handle nested structure
+              echo "LINT_ERRORS<<EOF" >> $GITHUB_ENV
+              cat extracted/lint-results/errors.md >> $GITHUB_ENV
+              echo "EOF" >> $GITHUB_ENV
+            fi
             echo "HAS_ERRORS=true" >> $GITHUB_OUTPUT
           else
             echo "HAS_ERRORS=false" >> $GITHUB_OUTPUT
@@ -76,25 +91,34 @@ jobs:
         with:
           script: |
             try {
-              const pulls = context.payload.workflow_run.pull_requests;
-              core.info(`Found ${pulls.length} triggering PR(s)`);
+              // First check if PR number was passed from the lint workflow
+              let prNumber = parseInt(process.env.PR_NUMBER);
 
-              if (pulls.length === 0) {
-                core.warning('No associated PRs; skipping comment.');
-                return;
+              // Fallback to the workflow_run PR data if available
+              if (!prNumber || isNaN(prNumber) || prNumber === 0) {
+                const pulls = context.payload.workflow_run.pull_requests;
+                core.info(`Looking for PR information in workflow_run: Found ${pulls.length} PR(s)`);
+
+                if (pulls.length === 0) {
+                  core.warning('No pull request information found. Skipping comment.');
+                  return;
+                }
+
+                prNumber = pulls[0].number;
               }
+
+              core.info(`Posting lint errors comment to PR #${prNumber}`);
 
               const body = process.env.LINT_ERRORS;
-              for (const pr of pulls) {
-                core.info(`Commenting lint errors on PR #${pr.number}`);
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo:  context.repo.repo,
-                  issue_number: pr.number,
-                  body
-                });
-              }
-              core.info('All comments posted');
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body
+              });
+
+              core.info('Lint errors comment posted successfully');
             } catch (err) {
               core.error('Failed to post lint comment:', err);
               core.setFailed(err.message);

--- a/.github/workflows/comment-test-results.yml
+++ b/.github/workflows/comment-test-results.yml
@@ -22,7 +22,10 @@ jobs:
               run_id: ${{ github.event.workflow_run.id }}
             });
             const art = artifacts.data.artifacts.find(a => a.name === "test-results");
-            if (!art) core.setFailed('No test-results artifact found');
+            if (!art) {
+              core.setFailed('No test-results artifact found');
+              return;
+            }
             const dl = await github.rest.actions.downloadArtifact({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -30,14 +33,30 @@ jobs:
               archive_format: 'zip'
             });
             require('fs').writeFileSync('test-results.zip', Buffer.from(dl.data));
+
       - name: Extract Test Results
         run: |
-          mkdir -p test-results
-          unzip -o test-results.zip -d test-results
-          echo "TIMESTAMP=$(cat test-results/timestamp.txt)" >> $GITHUB_ENV
-          echo "SUMMARY=$(cat test-results/summary.txt)" >> $GITHUB_ENV
-          echo "FAILED=$(cat test-results/failed.txt)" >> $GITHUB_ENV
-          if [ -f test-results/error.txt ]; then cp test-results/error.txt raw_error.txt; fi
+
+          mkdir -p extracted
+          unzip -o test-results.zip -d extracted
+
+          # Set environment variables from the extracted files
+          echo "TIMESTAMP=$(cat extracted/timestamp.txt)" >> $GITHUB_ENV
+          echo "SUMMARY=$(cat extracted/summary.txt)" >> $GITHUB_ENV
+          echo "FAILED=$(cat extracted/failed.txt)" >> $GITHUB_ENV
+
+          # Read PR information
+          if [ -f extracted/pr_number.txt ]; then
+            echo "PR_NUMBER=$(cat extracted/pr_number.txt)" >> $GITHUB_ENV
+          else
+            echo "PR_NUMBER=0" >> $GITHUB_ENV
+          fi
+
+
+          # Copy error file if it exists
+          if [ -f extracted/error.txt ]; then
+            cp extracted/error.txt raw_error.txt
+          fi
 
       - name: Post Test Results as PR Comment
         uses: actions/github-script@v6
@@ -46,13 +65,23 @@ jobs:
             const fs = require('fs');
 
             try {
-              const pulls = context.payload.workflow_run.pull_requests;
-              console.log(`Found ${pulls.length} triggering PR(s).`);
+              // First check if PR number was passed from the test workflow
+              let prNumber = parseInt(process.env.PR_NUMBER);
 
-              if (pulls.length === 0) {
-                console.warn('No pull requests found for this workflow run; skipping comment.');
-                return;
+              // Fallback to the workflow_run PR data if available
+              if (!prNumber || isNaN(prNumber) || prNumber === 0) {
+                const pulls = context.payload.workflow_run.pull_requests;
+                console.log(`Looking for PR information in workflow_run: Found ${pulls.length} PR(s).`);
+
+                if (pulls.length === 0) {
+                  console.warn('No pull request information found. Skipping comment.');
+                  return;
+                }
+
+                prNumber = pulls[0].number;
               }
+
+              console.log(`Posting comment to PR #${prNumber}`);
 
               const status = process.env.FAILED === 'true' ? '❌ FAILED' : '✅ PASSED';
               let commentBody = `#### Test Results: ${status}\n`
@@ -65,15 +94,14 @@ jobs:
                              + '\n```';
               }
 
-              for (const pr of pulls) {
-                console.log(`Commenting on PR #${pr.number}`);
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo:  context.repo.repo,
-                  issue_number: pr.number,
-                  body: commentBody
-                });
-              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: commentBody
+              });
+
+              console.log(`Successfully posted comment to PR #${prNumber}`);
 
             } catch (err) {
               console.error('🛑 Failed to post test results comment:', err);

--- a/.github/workflows/run-blits-tests.yml
+++ b/.github/workflows/run-blits-tests.yml
@@ -21,6 +21,12 @@ jobs:
       with:
         node-version: 20.16.0
 
+    - name: Save PR Information
+      run: |
+        echo '${{ github.event.pull_request.number }}' > ./pr_number.txt
+        echo '${{ github.event.pull_request.head.repo.full_name }}' > ./pr_repo.txt
+        echo '${{ github.event.pull_request.head.ref }}' > ./pr_branch.txt
+
     - name: Install Dependencies
       run: npm install
 
@@ -91,18 +97,14 @@ jobs:
            * Outputs results and saves result files
            */
           function outputResults(results) {
-            // Create test results directory and files
             try {
-              fs.mkdirSync('./test-results', { recursive: true });
-
-              // Write results files
-              fs.writeFileSync('./test-results/timestamp.txt', results.timestamp);
-              fs.writeFileSync('./test-results/summary.txt', results.summary);
-              fs.writeFileSync('./test-results/failed.txt', results.testsFailed.toString());
+              fs.writeFileSync('./timestamp.txt', results.timestamp);
+              fs.writeFileSync('./summary.txt', results.summary);
+              fs.writeFileSync('./failed.txt', results.testsFailed.toString());
 
               // Save error output if it exists
               if (results.error) {
-                fs.writeFileSync('./test-results/error.txt', results.error);
+                fs.writeFileSync('./error.txt', results.error);
               }
             } catch (err) {
               console.error('Error saving test results:', err);
@@ -124,7 +126,15 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: test-results
-        path: ./test-results/
+        path: |
+
+          ./timestamp.txt
+          ./summary.txt
+          ./failed.txt
+          ./error.txt
+          ./pr_number.txt
+          ./pr_repo.txt
+          ./pr_branch.txt
 
     # Fail the workflow if tests failed
     - name: Check Test Status

--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -19,6 +19,12 @@ jobs:
         # Needed to compare changes against base branch
         fetch-depth: 0
 
+    - name: Save PR Information
+      run: |
+        echo '${{ github.event.pull_request.number }}' > ./pr_number.txt
+        echo '${{ github.event.pull_request.head.repo.full_name }}' > ./pr_repo.txt
+        echo '${{ github.event.pull_request.head.ref }}' > ./pr_branch.txt
+
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
@@ -110,7 +116,11 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: lint-results
-        path: ./lint-results/
+        path: |
+          ./lint-results/
+          ./pr_number.txt
+          ./pr_repo.txt
+          ./pr_branch.txt
 
     # Fail the workflow if linting errors found
     - name: Check Lint Status


### PR DESCRIPTION
Fixes the issue where PR comments weren't working for pull requests from forked repositories. 

The solution gets PR numbers during the initial workflow and passes them via artifacts to the comment workflows, bypassing the limitation where `workflow_run` events lack PR information for cross-repository PRs.

The solution will work after the changes are merged into `master` branch because `workflow_run` events use workflows from the default branch.