### PR TITLE
fix: set isProcessing to false when the utterance is cancelled

### DIFF
--- a/src/announcer/announcer.js
+++ b/src/announcer/announcer.js
@@ -70,6 +70,7 @@ const addToQueue = (message, politeness, delay = false) => {
   done.cancel = () => {
     const index = queue.findIndex((item) => item.id === id)
     if (index !== -1) queue.splice(index, 1)
+    isProcessing = false
     resolveFn('canceled')
   }
 


### PR DESCRIPTION
# What does this PR do?

This PR sets `isProcessing` to false when the utterance is cancelled, so that the queue is free and can process the next utterance