### PR TITLE
Release 1.29.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+_28 may 2025_
+
+## v1.29.2
+
+- Added end of life flag to prevent timers, intervals and listeners to be registered after component destroy
+
 _22 may 2025_
 
 ## v1.29.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lightningjs/blits",
-  "version": "1.29.1",
+  "version": "1.29.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lightningjs/blits",
-      "version": "1.29.1",
+      "version": "1.29.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@lightningjs/msdf-generator": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightningjs/blits",
-  "version": "1.29.1",
+  "version": "1.29.2",
   "description": "Blits: The Lightning 3 App Development Framework",
   "bin": "bin/index.js",
   "exports": {

--- a/src/component/base/events.js
+++ b/src/component/base/events.js
@@ -29,6 +29,8 @@ export default {
   },
   $listen: {
     value: function (event, callback, priority = 0) {
+      // early exit when component is marked as end of life
+      if (this.eol === true) return
       eventListeners.registerListener(this, event, callback, priority)
     },
     writable: false,

--- a/src/component/base/methods.js
+++ b/src/component/base/methods.js
@@ -52,6 +52,7 @@ export default {
   },
   destroy: {
     value: function () {
+      this.eol = true
       this.lifecycle.state = 'destroy'
       this.$clearTimeouts()
       this.$clearIntervals()

--- a/src/component/base/timeouts_intervals.js
+++ b/src/component/base/timeouts_intervals.js
@@ -20,6 +20,8 @@ import symbols from '../../lib/symbols.js'
 export default {
   $setTimeout: {
     value: function (fn, ms, ...params) {
+      // early exit when component is marked as end of life
+      if (this.eol === true) return
       const timeoutId = setTimeout(
         () => {
           this[symbols.timeouts] = this[symbols.timeouts].filter((id) => id !== timeoutId)
@@ -59,6 +61,8 @@ export default {
   },
   $setInterval: {
     value: function (fn, ms, ...params) {
+      // early exit when component is marked as end of life
+      if (this.eol === true) return
       const intervalId = setInterval(() => fn.apply(null, params), ms, params)
       this[symbols.intervals].push(intervalId)
       return intervalId


### PR DESCRIPTION
- Added end of life flag to prevent timers, intervals and listeners to be registered after component destroy
