### PR TITLE
Renamed outOfViewport event to outOfBounds.

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -298,7 +298,7 @@ const Component = (name = required('name'), config = required('config')) => {
 
       // outOfViewport event emitting a lifecycle exit event
       if (config.hooks.exit) {
-        this[symbols.wrapper].node.on('outOfViewport', () => {
+        this[symbols.wrapper].node.on('outOfBounds', () => {
           this.lifecycle.state = 'exit'
         })
       }

--- a/src/component.test.js
+++ b/src/component.test.js
@@ -322,8 +322,8 @@ test('Component - Instance should initialize hook events', (assert) => {
   )
   assert.equal(
     nodeCalls[3].args[0],
-    'outOfViewport',
-    '`outOfViewport` event should be registered in the wrapper'
+    'outOfBounds',
+    '`outOfBounds` event should be registered in the wrapper'
   )
   assert.end()
 })


### PR DESCRIPTION
Updated name of out of viewport event which got renamed in the renderer at one point

Note, the example in the renderer still uses outOfViewport: https://github.com/lightning-js/renderer/blob/feat/touch-detection/examples/tests/render-bounds.ts#L31