### PR TITLE
Refactor/focus

### DIFF
--- a/src/component/base/methods.js
+++ b/src/component/base/methods.js
@@ -40,7 +40,6 @@ export default {
      * @this {import('../../component').BlitsComponent}
      */
     value: function (e) {
-      this[symbols.state].hasFocus = true
       Focus.set(this, e)
     },
     writable: false,

--- a/src/components/RouterView.js
+++ b/src/components/RouterView.js
@@ -43,9 +43,6 @@ export default () =>
       destroy() {
         window.removeEventListener('hashchange', hashchangeHandler, false)
       },
-      focus() {
-        this.activeView && this.activeView.$focus()
-      },
     },
     input: {
       back(e) {

--- a/src/lib/lifecycle.js
+++ b/src/lib/lifecycle.js
@@ -76,6 +76,8 @@ export default {
       )
       this.previous = this.current
       this.current = v
+      if (this.current === 'focus') this.component[symbols.state].hasFocus = true
+      if (this.current === 'unfocus') this.component[symbols.state].hasFocus = false
       // emit 'private' hook
       privateEmit(v, this.component[symbols.identifier], this.component)
       // emit 'public' hook


### PR DESCRIPTION
Refactor for focus to make it work more reliably"

- Fixes issue with not all pages in the chain calling unfocus hook when programatically changing the focus (in an emit for example).
- Ensures that $hasFocus is always set correctly.
- Optimizes focus chains