### PR TITLE
feat: Optionally skip passing focus to RouterView on navigate

### DIFF
--- a/docs/router/basics.md
+++ b/docs/router/basics.md
@@ -96,6 +96,8 @@ export default Blits.Component('Poster', {
 
 Whenever you navigate to a new page, the URL hash will automatically be updated. Unless specified otherwise, navigating to a new page, will add that route to the history stack. The `back` input action is automatically wired up to navigate back down the history stack.
 
+By default, every time you navigate to a new route, the application focus will be automatically passed to the newly loaded page. If you instead want to maintain the current focus (for example in a widget that sits above your RouterView), you can use `passFocus: false` as part of the router options.
+
 ## Deeplinking
 
 The Router plugin has support for deeplinking. When the App is loaded with a URL hash (i.e. `#/pages/settings/network`), the router will try to match that hash to a defined route. This means that your app can be deep linked into, by simply providing the correct URL hash.

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -337,8 +337,10 @@ export const navigate = async function () {
       // keep reference to the previous focus for storing in cache
       previousFocus = Focus.get()
 
-      // set focus to the view that we're routing to
-      focus ? focus.$focus() : /** @type {BlitsComponent} */ (view).$focus()
+      // set focus to the view that we're routing to (unless explicitly disabling passing focus)
+      if (route.options.passFocus !== false) {
+        focus ? focus.$focus() : /** @type {BlitsComponent} */ (view).$focus()
+      }
 
       // apply before settings to holder element
       if (route.transition.before) {


### PR DESCRIPTION
In our application we've got a navigation bar that sits about the RouterView in our App component, the idea being that this navigation bar is available on every page, and has the logic to navigate between them while remaining visible the whole time.

We have a pain point with the current router implementation when navigating between pages in that anytime you use `$router.to`, focus automatically gets passed to the RouterView and then along to the page component. For us this means that our nav gets unfocused every time we swap pages rather than what we need which is for the nav bar to remain in focus until you scroll down into a page.

To support this use case, I've added a check for a `passFocus` option when navigating. This won't affect the current logic when unused, but if set to `false` as part of the router options, the current focus will not change when navigating.

Example:
`this.$router.to('home', {id: 123456}, {passFocus: false});`

This would prevent us needing to constantly fight the current focus and try and refocus the nav when going between pages