### PR TITLE
feat: skip ancestors that don't handle input event in focus chain

### DIFF
--- a/docs/components/user_input.md
+++ b/docs/components/user_input.md
@@ -72,6 +72,21 @@ When a component handles a key press by having a corresponding function specifie
 }
 ```
 
+If you don't want to focus the direct parent when propagating an input event, you can return `false` within the handler, which will find the nearest ancestor that handles the input event and immediately move focus to it without triggering the focus handlers for any elements inbetween.
+
+```javascript
+{
+  input: {
+    up() {
+      // on some condition where your component doesn't need focus anymore, return false to propagate focus to the nearest ancestor that handles the same input
+      if (focusIndex === 0) {
+        return false;
+      }
+    },
+  }
+}
+```
+
 ## Intercepting key input
 
 In addition to the Event handling chain explained above. Blits offers the option to _intercept_ key presses at the root level of the Application, before they reach the currently focused Component. This can be useful in certain situation where you want to globally disable all key presses, or when implementing an override key press handler.

--- a/src/focus.js
+++ b/src/focus.js
@@ -93,7 +93,11 @@ export default {
       cb = inputEvents.any.call(componentWithInputEvent, event)
     }
 
-    if (cb !== undefined) {
+    // if the callback returns false, fallback to the nearest ancestor with a matching input event
+    if (cb === false && !!componentWithInputEvent.parent) {
+      const ancestorWithInputEvent = getComponentWithInputEvent(componentWithInputEvent.parent, key)
+      ancestorWithInputEvent?.$focus(event)
+    } else if (cb !== undefined) {
       keyUpCallbacks.set(event.code, cb)
     }
   },


### PR DESCRIPTION
I was having an issue with calling `this.parent.$focus(e)` inside some input handlers, where the direct parent would have its focus hook called even if it didn't have a handler for the given input key. I opened an issue for it here https://github.com/lightning-js/blits/issues/436 with a playground to showcase the problem.

Although I'm unsure if that is intended functionality, assuming that it is I found an alternative way to avoid triggering the focus hook for any ancestors that don't implement the specific key event being propagated.

This involves returning false out of an input handler to denote that you want to pass focus up the chain, and then searching for the nearest ancestor and skipping to immediately focus them instead of the direct parent, closer to how it worked in L2 as far as I remember.

I've added to the docs to explain the idea, but if the original issue isn't intended there's likely a better way to fix it than this!