### PR TITLE
fix(router): update routing state before component init to avoid stal…

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -220,6 +220,11 @@ export const navigate = async function () {
         ...navigationData,
         ...queryParamsData,
       }
+      state.path = route.path
+      state.params = route.params || {}
+      state.hash = hash
+      state.data = route.data || {}
+
       // Adding the location hash to the route if it exists.
       if (hash !== null) {
         route.hash = hash
@@ -367,11 +372,6 @@ export const navigate = async function () {
           removeView(previousRoute, oldView, route.transition.out)
         }
       }
-
-      state.path = route.path
-      state.params = route.params
-      state.hash = hash
-      state.data = route.data
 
       // apply in transition
       if (route.transition.in) {


### PR DESCRIPTION
### Problem
The reactive routing state (`state.path`, `state.params`, `state.data`, `state.hash`) was being updated **after** component instantiation in the `navigate()` function. As a result, components accessing `$router.state` during their `init()` hook were seeing stale or uninitialized values.

### Solution
Moved the router state update block immediately after route matching (`matchHash`) and before any lifecycle hooks, transitions, or view instantiation begin. This ensures that components have access to the correct route context even during their `init()` lifecycle phase.

### Changes
- Updated `navigate()` to set `state.path`, `state.params`, `state.data`, and `state.hash` earlier
- Ensures route context is reactive and accurate across all lifecycle stages

### Result
Components can now reliably access updated routing information in both `init()` and `ready()` hooks.

