### PR TITLE
fix: use initial value of navigatingBack in router removeView

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -390,7 +390,7 @@ export const navigate = async function () {
         shouldAnimate = true
         const oldView = this[symbols.children].splice(1, 1).pop()
         if (oldView) {
-          removeView(previousRoute, oldView, route.transition.out)
+          removeView(previousRoute, oldView, route.transition.out, navigatingBack)
         }
       }
 
@@ -432,7 +432,7 @@ export const navigate = async function () {
  * @param {BlitsComponent} view
  * @param {Object} transition
  */
-const removeView = async (route, view, transition) => {
+const removeView = async (route, view, transition, navigatingBack) => {
   // apply out transition
   if (transition) {
     if (Array.isArray(transition)) {


### PR DESCRIPTION
In the router's `removeView` method, I was noticing that when backtracking through pages some of them were being kept alive even though `navigatingBack` should have been set to true - destroying them.

The issue is that when you use page transitions with backtracking, the value of `navigatingBack` was being reset to false before the transition had finished, so when the `removeView` method was checking if we were navigating back to destroy the page, it always came back false.

To fix this, I've added an extra local `navigatingBack` param to the `removeView` method, so that it gets set during the navigation flow, and then won't be affected by the global value while any transitions are happening. This fixes the issue and means that when backtracking, pages are being destroyed as expected