### PR TITLE
Clone route objects to avoid passing stale props

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -176,6 +176,7 @@ export const matchHash = (path, routes = []) => {
   }
 
   if (matchingRoute) {
+    matchingRoute = Object.assign({}, matchingRoute) // clone to avoid overwriting original options
     matchingRoute.options = { ...defaultOptions, ...matchingRoute.options, ...overrideOptions }
     if (!matchingRoute.data) {
       matchingRoute.data = {}
@@ -215,7 +216,7 @@ export const navigate = async function () {
   state.navigating = true
   let reuse = false
   if (this.parent[symbols.routes]) {
-    let previousRoute = currentRoute //? Object.assign({}, currentRoute) : undefined
+    let previousRoute = currentRoute ? Object.assign({}, currentRoute) : undefined
     const { hash, path, queryParams } = getHash()
     let route = matchHash(path, this.parent[symbols.routes])
 


### PR DESCRIPTION
This is related to an issue I posted https://github.com/lightning-js/blits/issues/461 where router options were getting stored in the original route object on every navigation - causing these assumed temporary options to be used every time you try navigate to a page. This example shows the problem using inHistory
https://playground.lightningjs.io/#RVMs5ESST0HZ

There was another related issue I started noticing when trying to use keepAlive with dynamic routes, where the pages were being saved in cache using the wrong hash. This is also because of a stale route object being used in `removeView` when setting the cache. I've setup another example here to demonstrate the problem - use 1/2/3 to nav between pages and see that sometimes the wrong number appears on screen because the cache has the wrong view attached
https://playground.lightningjs.io/#avFQk5g1Wwlr

To fix both these problems, instead of passing routes by reference, we can clone the starting values so that the correct options/views are being used during the navigate function. One of these fixes looks like it had been used before but was commented out, so if there's a particular reason this won't work let me know! It seemed to fix my issue but might be causing some other problems.