### PR TITLE
Test coverage tuesday/router state tests

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -220,10 +220,6 @@ export const navigate = async function () {
         ...navigationData,
         ...queryParamsData,
       }
-      state.path = route.path
-      state.params = route.params || {}
-      state.hash = hash
-      state.data = route.data || {}
 
       // Adding the location hash to the route if it exists.
       if (hash !== null) {
@@ -285,6 +281,13 @@ export const navigate = async function () {
         }
         Announcer.speak(route.announce.message, route.announce.politeness)
       }
+
+      // Update router state after announcements and final route resolution,
+      // right before initializing or restoring the view
+      state.path = route.path
+      state.params = route.params || {}
+      state.hash = route.hash
+      state.data = route.data || {}
 
       if (!view) {
         // create a holder element for the new view

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -220,6 +220,11 @@ export const navigate = async function () {
         ...navigationData,
         ...queryParamsData,
       }
+      state.path = route.path
+      state.params = route.params || {}
+      state.hash = hash
+      state.data = route.data || {}
+
       // Adding the location hash to the route if it exists.
       if (hash !== null) {
         route.hash = hash
@@ -367,11 +372,6 @@ export const navigate = async function () {
           removeView(previousRoute, oldView, route.transition.out)
         }
       }
-
-      state.path = route.path
-      state.params = route.params
-      state.hash = hash
-      state.data = route.data
 
       // apply in transition
       if (route.transition.in) {

--- a/src/router/router.test.js
+++ b/src/router/router.test.js
@@ -16,7 +16,10 @@
  */
 
 import test from 'tape'
-import { matchHash, getHash, to } from './router.js'
+import { matchHash, getHash, to, navigate, state } from './router.js'
+import { stage } from '../launch.js'
+import Component from '../component.js'
+import symbols from '../lib/symbols.js'
 
 const mockComponents = {
   Home: () => {},
@@ -532,5 +535,67 @@ test('Get Hash from URL when navigating using to() method', (assert) => {
     'The result object should contain a path key with hash without #'
   )
 
+  assert.end()
+})
+
+test('Router updates state.path, state.params, and state.data correctly', async (assert) => {
+  // Stub stage.element to avoid engine dependency
+  const originalElement = stage.element
+  stage.element = ({ parent }) => ({
+    populate() {},
+    set() {},
+    parent,
+  })
+
+  const Capturing = Component('Capturing', {
+    template: '<Element />',
+    code: {
+      render: () => ({
+        elms: [
+          {
+            [symbols.holder]: {},
+            node: {},
+          },
+        ],
+        cleanup: () => {},
+      }),
+      effects: [],
+      init() {
+        // just to prove component is constructed
+        this.$router && assert.ok(true, 'Component accessed $router')
+      },
+    },
+  })
+
+  const host = {
+    parent: {
+      [symbols.routes]: [
+        {
+          path: '/cap/:id',
+          component: Capturing,
+          options: { inHistory: true, passFocus: false },
+          data: { title: 'Test' },
+        },
+      ],
+    },
+    [symbols.children]: [{}],
+    [symbols.props]: {},
+  }
+
+  // Navigate
+  to('/cap/123?lang=en', { dynamic: true })
+  await navigate.call(host)
+
+  // Assertions directly against router.js `state`
+  assert.equal(state.path, 'cap/:id', 'state.path matches route definition')
+  assert.deepEqual(state.params, { id: '123' }, 'state.params extracted correctly')
+  assert.deepEqual(
+    state.data,
+    { title: 'Test', dynamic: true, lang: 'en' },
+    'state.data merged correctly (route + navigation + query)'
+  )
+
+  // Restore
+  stage.element = originalElement
   assert.end()
 })


### PR DESCRIPTION
This PR introduces a unit test to verify that the router state (state.path, state.params, state.data) is correctly set and accessible inside the init() lifecycle hook of a component.

Changes:

Updated navigate() to set state.path, state.params, state.data earlier.
Added a test that stubs stage.element to avoid engine dependency.
Validates that router state is populated before component initialization.
Ensures init() hook can safely access this.$router.state.

Why

Previously, there was uncertainty whether router state was available during init(). This test guarantees state properties are injected at the correct lifecycle stage, preventing regressions.