### PR TITLE
Assign null to router state data

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -320,6 +320,7 @@ export const navigate = async function () {
       state.path = route.path
       state.params = route.params || {}
       state.hash = route.hash
+      state.data = null
       state.data = route.data || {}
 
       if (!view) {


### PR DESCRIPTION
Assigning null to router state data property before assigning actual route data. This will make sure not triggering reactivity effects of previous route component