### PR TITLE
fix: added keepPreviousAlive as override in router.to

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -235,7 +235,19 @@ declare module '@lightningjs/blits' {
      */
     keepAlive?: true
   }
+  /**
+   * Navigation Options that can be used when navigating to a new route
+   */
+  type NavigationOverride = {
+    /**
+     * Where the previous page should be kept alive when navigating away. Can be useful
+     * to a page when navigated back to is in the exact same state when navigated away from
+     */
+    keepPreviousAlive?: boolean
+  }
+
   export type RouteOptions = ConcurrentRouteOpts & MutualExclusiveRouteOpts;
+  export type RouteOverrideOptions = RouteOptions & NavigationOverride
 
   export interface Router {
     /**
@@ -243,7 +255,7 @@ declare module '@lightningjs/blits' {
      *
      * @param {string}
     */
-    to(location: string, data?: RouteData, options?: RouteOptions): void;
+    to(location: string, data?: RouteData, options?: RouteOverrideOptions): void;
 
     /**
      * Navigate to the previous location

--- a/index.d.ts
+++ b/index.d.ts
@@ -236,7 +236,7 @@ declare module '@lightningjs/blits' {
     keepAlive?: true
   }
   /**
-   * Navigation Options that can be used when navigating to a new route
+   * Navigation override options that can be used when navigating to a new route
    */
   type NavigationOverrides = {
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -238,7 +238,7 @@ declare module '@lightningjs/blits' {
   /**
    * Navigation Options that can be used when navigating to a new route
    */
-  type NavigationOverride = {
+  type NavigationOverrides = {
     /**
      * Where the previous page should be kept alive when navigating away. Can be useful
      * to a page when navigated back to is in the exact same state when navigated away from
@@ -247,7 +247,7 @@ declare module '@lightningjs/blits' {
   }
 
   export type RouteOptions = ConcurrentRouteOpts & MutualExclusiveRouteOpts;
-  export type RouteOverrideOptions = RouteOptions & NavigationOverride
+  export type RouteOverrideOptions = RouteOptions & NavigationOverrides
 
   export interface Router {
     /**

--- a/src/router/router.test.js
+++ b/src/router/router.test.js
@@ -485,7 +485,7 @@ test('Get route object from Match hash when navigating using to() method', (asse
   )
   assert.equal(
     Object.keys(result.options).length,
-    4,
+    5,
     'The results object should contain the default options object'
   )
 
@@ -496,6 +496,7 @@ test('Get route object from Match hash when navigating using to() method', (asse
       ['keepAlive', false],
       ['passFocus', true],
       ['reuseComponent', false],
+      ['keepPreviousAlive', false],
     ],
     'The results object should contain the default options object'
   )


### PR DESCRIPTION
I have added a new option which can be passed when calling router.to(). 
When navigating this option will cache the previous page (page being navigated from) so when navigating back focus etc is remained. 
Very similar to keepAlive but is passed only as an override option when calling a .to() navigation. 