### PR TITLE
Fix early return in element property setting logic

### DIFF
--- a/src/engines/L3/element.js
+++ b/src/engines/L3/element.js
@@ -578,10 +578,11 @@ const Element = {
       for (let i = 0; i < propsKeys.length; i++) {
         // todo: fix code duplication
         if (isTransition(value) === true) {
-          return this.animate(propsKeys[i], this.props.props[propsKeys[i]], value.transition)
+          this.animate(propsKeys[i], this.props.props[propsKeys[i]], value.transition)
+        } else {
+          // set the prop to the value on the node
+          this.node[propsKeys[i]] = this.props.props[propsKeys[i]]
         }
-        // set the prop to the value on the node
-        this.node[propsKeys[i]] = this.props.props[propsKeys[i]]
       }
     }
 


### PR DESCRIPTION
 Removed the early `return` statement in the transition handling
- Restructured the logic to use proper `if-else` branching
- Now both transition animations and regular property setting can occur as intended