### PR TITLE
fix: reintroduce meta options on routes

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -220,6 +220,7 @@ const makeRouteObject = (route, overrides) => {
     hooks: route.hooks || {},
     data: { ...route.data, ...navigationData, ...overrides.queryParams },
     params: overrides.params || {},
+    meta: route.meta || {},
   }
 
   return cleanRoute


### PR DESCRIPTION
I was trying to use the `meta` prop on a route (listed in the router documentation https://lightningjs.io/v3-docs/blits/router/basics.html)  and found that I wasn't seeing them come through in the `before` and `beforeEach` hooks on the router.
Not sure if this had been working before, but think it's a useful thing so just added a quick fix to make sure the meta props get propagated to the hooks