### PR TITLE
Fix - Router navigation cancel on error or rejected "before" hook

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -78,8 +78,9 @@ let navigationData = {}
 let navigatingBack = false
 let navigatingBackTo = undefined
 let previousFocus
-let preventHashChangeNavigation = false // Skips internal router navigation when set to true only for the next "navigate" execution, needed for window.history management
-
+// Skips internal router navigation when set to true only for the next "navigate"
+// execution, needed for window.history management
+let preventHashChangeNavigation = false
 /**
  * Get the current hash
  * @returns {Hash}
@@ -264,7 +265,7 @@ export const navigate = async function () {
               return
             }
           } catch (error) {
-            console.error('Error or Rejected Promise in "BeforeEach" Hooks', error)
+            Log.error('Error or Rejected Promise in "BeforeEach" Hook', error)
 
             preventHashChangeNavigation = true
             currentRoute = previousRoute
@@ -303,7 +304,7 @@ export const navigate = async function () {
             return
           }
         } catch (error) {
-          console.error('Error or Rejected Promise in "Before" Hook', error)
+          Log.error('Error or Rejected Promise in "Before" Hook', error)
 
           preventHashChangeNavigation = true
           currentRoute = previousRoute


### PR DESCRIPTION
### Code change description:

- Now when a "before" hook is executed, this is done inside a try-catch. This way the before hook will behave exactly as before when executed succesfully, and now it will catch errors and promise rejections.
- In the catch execution a flag is set to true to prevent a navigate function execution, this way the browser history can be reverted.
- the currentRoute is set back to the "previousRoute" to prevent incorrect future back() navigations.


### Bug description:

When a route is set to do checks before navigating, the "before" hook works incorrectly when trying to prevent navigation.

- True/false returned:
     - Documentation states that a boolean can be returned, but this is not possible and won't have any effect in the code.
- String or Route returned:
     - OK
- Promise<string|Route> returned:
     - If resolve(to): Navigates away to the new route.
     - If resolve(from): Navigates to the same current route (Refreshes the current page) 
     - **If reject(): Error, app stucked**
     - **If resolve(undefinedPath): Navigation prevented, Blits error shown in console.**