### PR TITLE
feat: add effects prop support to Sprite component

### DIFF
--- a/src/components/Sprite.js
+++ b/src/components/Sprite.js
@@ -22,9 +22,9 @@ import symbols from '../lib/symbols.js'
 export default () =>
   Component('Sprite', {
     template: `
-      <Element w="100%" h="100%" :texture="$texture" :color="$color" />
+      <Element w="100%" h="100%" :texture="$texture" :color="$color" :effects="$effects" />
     `,
-    props: ['image', 'map', 'frame', 'color'],
+    props: ['image', 'map', 'frame', 'color', 'effects'],
     state() {
       return {
         spriteTexture: null,


### PR DESCRIPTION
- Add effects prop to Sprite component props array
- Pass effects prop to Element in template
- Enables visual effects to be applied to sprite elements