### PR TITLE
Updated scale with scaleX & scaleY

### DIFF
--- a/src/engines/L3/element.js
+++ b/src/engines/L3/element.js
@@ -357,7 +357,8 @@ const propsTransformer = {
         this.props['scaleY'] = v.y
       }
     } else {
-      this.props['scale'] = v
+      this.props['scaleX'] = v
+      this.props['scaleY'] = v
     }
   },
   set show(v) {


### PR DESCRIPTION
To resolve the snaps issue observed with scale transition, setting axix based prop instead of updating indivual scale property