### PR TITLE
Support for specifying a type in the src attribute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@lightningjs/msdf-generator": "^1.2.0",
-        "@lightningjs/renderer": "^2.19.1"
+        "@lightningjs/renderer": "^2.20.0"
       },
       "bin": {
         "blits": "bin/index.js"
@@ -1179,9 +1179,9 @@
       }
     },
     "node_modules/@lightningjs/renderer": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/@lightningjs/renderer/-/renderer-2.19.1.tgz",
-      "integrity": "sha512-sxI9u91zqyYZrSqR9vQma0eWtUr0p32A2mFuX0l1K9bBuXt6F99cwJetM/Gya4vkquiPsVT++w+wfjQyzfYoAg==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@lightningjs/renderer/-/renderer-2.20.0.tgz",
+      "integrity": "sha512-Ko71Zs2GxeaXb4fcYK/jWWu2txUtx9v1Yg49LoFNqTUF2aCdINNRlj4l0ghlE8SunQWm3pRn38HUr/kR9wt97A==",
       "hasInstallScript": true,
       "engines": {
         "node": ">= 20.9.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@lightningjs/msdf-generator": "^1.2.0",
-    "@lightningjs/renderer": "^2.19.1"
+    "@lightningjs/renderer": "^2.20.0"
   },
   "repository": {
     "type": "git",

--- a/src/engines/L3/element.js
+++ b/src/engines/L3/element.js
@@ -526,8 +526,6 @@ const Element = {
       this.props.props['color'] = 0
     }
 
-    console.log('props', this.props.props)
-
     this.node = props.__textnode
       ? renderer.createTextNode({ ...textDefaults, ...this.props.props })
       : renderer.createNode(this.props.props)


### PR DESCRIPTION
For compressed textures we may need to add an imageType when the compressed texture can't be derived from the url. Same is valid for svg. This change allows to use object notation in the `src` attribute allowing to pass the src as well as the type.