### PR TITLE
fix(generator): rewrite plugin helpers in :for loop effects

### DIFF
--- a/src/lib/codegenerator/generator.js
+++ b/src/lib/codegenerator/generator.js
@@ -409,7 +409,7 @@ const generateForLoopCode = function (templateObject, parent) {
     .replace(')', '')
     .split(/\s*,\s*/)
 
-  const scopeRegex = new RegExp(`(scope\\.(?!${item}\\.|${index}|key)(\\w+))`, 'gi')
+  const scopeRegex = new RegExp(`(scope\\.(?!${item}\\.|${index}|key)([\\w$]+))`, 'gi')
 
   // local context
   const ctx = {


### PR DESCRIPTION
- extend scopeRegex to match $-prefixed helpers (e.g. $language) using ([\\w$]+)
- ensure scope.$language in :for effects is rewritten to component.$language