### PR TITLE
Addressed the issue with using a computed prop as the source for loop data.

### DIFF
--- a/src/component/setup/index.js
+++ b/src/component/setup/index.js
@@ -48,6 +48,11 @@ export default function (component, config) {
   // // setup computed
   if (config.computed) setupComputed(component, config.computed)
 
+  // // setup computedThisRefVars
+  if (config.computedThisRefVars) {
+    component[symbols.computedThisRefVars] = config.computedThisRefVars
+  }
+
   // // setup watchers
   if (config.watch) setupWatch(component, config.watch)
 

--- a/src/lib/codegenerator/generator.js
+++ b/src/lib/codegenerator/generator.js
@@ -622,8 +622,13 @@ const generateForLoopCode = function (templateObject, parent) {
     }
 
     component[Symbol.for('effects')].push(eff${forStartCounter})
+    const trackingKeys = ['${effectKey}', ${effectKeys.join(',')}]
 
-    effect(eff${forStartCounter}, ['${effectKey}', ${effectKeys.join(',')}])
+    if (component[Symbol.for('computedKeys')] && component[Symbol.for('computedKeys')].indexOf('${effectKey}') !== -1) {
+      trackingKeys.push(...component[Symbol.for('computedThisRefVars')]['${effectKey}'])
+    }
+
+    effect(eff${forStartCounter}, trackingKeys)
   `)
 
   ctx.cleanupCode.push(`

--- a/src/lib/codegenerator/generator.js
+++ b/src/lib/codegenerator/generator.js
@@ -35,6 +35,7 @@ export default function (templateObject = { children: [] }, devMode = false) {
       'let inSlot = false',
       'let slotChildCounter = 0',
       'let cmps = []',
+      'let trackingKeys = []',
     ],
     effectsCode: [],
     cleanupCode: [
@@ -622,7 +623,7 @@ const generateForLoopCode = function (templateObject, parent) {
     }
 
     component[Symbol.for('effects')].push(eff${forStartCounter})
-    const trackingKeys = ['${effectKey}', ${effectKeys.join(',')}]
+    trackingKeys = ['${effectKey}', ${effectKeys.join(',')}]
 
     if (component[Symbol.for('computedKeys')] && component[Symbol.for('computedKeys')].indexOf('${effectKey}') !== -1) {
       trackingKeys.push(...component[Symbol.for('computedThisRefVars')]['${effectKey}'])

--- a/src/lib/symbols.js
+++ b/src/lib/symbols.js
@@ -47,6 +47,7 @@
  * @property {symbol} isComponent
  * @property {symbol} effects
  * @property {symbol} removeGlobalEffects
+ * @property {symbol} computedThisRefVars
  */
 
 /**
@@ -58,7 +59,6 @@ export default {
   cleanup: Symbol('cleanup'),
   currentView: Symbol('currentView'),
   cursorTagStart: Symbol('cursorTagStart'),
-  computedKeys: Symbol('computedKeys'),
   destroy: Symbol('destroy'),
   rendererEventListeners: Symbol('rendererEventListeners'),
   getChildren: Symbol('getChildren'),
@@ -113,4 +113,9 @@ export default {
   effects: Symbol.for('effects'),
   // Symbol 'removeGlobalEffects' utilized within generated code
   removeGlobalEffects: Symbol.for('removeGlobalEffects'),
+  // Symbol 'computedThisRefVars' utilized within generated code
+  computedThisRefVars: Symbol.for('computedThisRefVars'),
+
+  // Symbol 'computedKeys' utilized within generated code
+  computedKeys: Symbol.for('computedKeys'),
 }


### PR DESCRIPTION
Observed that while using computed property as for-loop data collection then for-loop effect is not tracking for all the other instance variables which are using in computed property function defintion. Ideally changes to any property inside computed function should execute for-loop again, This PR will actually collect list of those component refferences inside each computed method and track for-loop for all those component variables.