### PR TITLE
Add Codecov integration and badges

### DIFF
--- a/.github/workflows/master-coverage.yml
+++ b/.github/workflows/master-coverage.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 20.16.0
+
+    - name: Install Dependencies
+      run: npm install
+
+    - name: Run Tests with Coverage
+      run: npx c8 --reporter=lcov --reporter=text node scripts/runTests.js
+
+    - name: Upload Coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage/lcov.info
+        flags: unittests
+        name: blits-coverage
+        fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Blits - Lightning 3 App Development Framework
 
+![npm](https://img.shields.io/npm/v/@lightningjs/blits?label=Version&color=blue) ![License](https://img.shields.io/github/license/lightning-js/blits?label=License&color=blue) ![Tests](https://github.com/lightning-js/blits/workflows/Tests/badge.svg) ![Coverage](https://img.shields.io/codecov/c/github/lightning-js/blits/master?label=Coverage) ![npm](https://img.shields.io/npm/dm/@lightningjs/blits?label=Downloads&color=blue)
+
 With Blits, the App Development Framework for Lightning 3, it becomes a breeze to build great Lightning 3 applications.
 
 Blits is built on top of the Lightning 3 Rendererer and aims to provide a **great developer experience**, making it fun and easy to build your apps!


### PR DESCRIPTION
Adds Codecov integration to track code coverage on master branch and includes other repository badges in README.

## Changes
- New workflow to upload coverage reports to Codecov on master branch pushes
- Added badges for version, license, tests, coverage, and downloads

## Setup
I have already added required Codecov global upload token to the repo secrets (`CODECOV_TOKEN`). Tokenless setup is also possible by install Codecov app to the repo from a Codecov account. The current workflow uses the upload token.

## Preview

<img width="1288" height="504" alt="Screenshot 2025-11-28 at 00 05 19" src="https://github.com/user-attachments/assets/c2d04389-1beb-49e2-a787-423dc40c2cd1" />
