### PR TITLE
feat: expose ComponentCustomProperties as a module-augmentation extension point

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -367,11 +367,11 @@ declare module '@lightningjs/blits' {
   // module augmentation in your app, without changing core types.
   // Note: `ComponentBase` extends this interface, so augmented fields appear in all
   // hooks, methods, input, computed, and watch.
-  export interface ComponentCustomProperties {
+  export interface CustomComponentProperties {
     // Empty by design: extend in your app via TypeScript module augmentation.
   }
 
-  export interface ComponentBase extends ComponentCustomProperties {
+  export interface ComponentBase extends CustomComponentProperties {
     /**
     * Indicates whether the component currently has focus
     *


### PR DESCRIPTION
**Summary**

- Establishes ComponentCustomProperties as the intended extension point for consumer-side module augmentation.
- Enables apps/plugins to type custom fields on the component this (e.g., $telemetry) without modifying core types or annotating hooks.

**Motivation**

- this typing in Blits flows from ComponentBase via ComponentContext (ThisType<... & ComponentBase>).
- Consumers need IntelliSense for custom fields added by plugins or app-level conventions.
- Type aliases cannot be merged; providing a mergeable interface lets projects safely extend this via module augmentation.


**Usage Example (consumer project)**

Example consumer side type definition file like `blits.d.ts`
```
import '@lightningjs/blits';

export interface Telemetry {
  recordEvent(eventName: string, payload?: Record<string, unknown>): void;
  recordException(error: Error, payload?: Record<string, unknown>): void;
}

declare module '@lightningjs/blits' {
  interface ComponentCustomProperties {
    $telemetry?: Telemetry;
  }
}
```
