### PR TITLE
fix: improve the initial state of created blits project

### DIFF
--- a/packages/create-blits/boilerplate/common/eslint/package.json
+++ b/packages/create-blits/boilerplate/common/eslint/package.json
@@ -1,6 +1,7 @@
 {
   "lint-staged": {
-    "*.js": [
+    "*.?(c|m)[jt]s": [
+      "prettier --write",
       "eslint --fix"
     ]
   },

--- a/packages/create-blits/boilerplate/js/default/.prettierrc
+++ b/packages/create-blits/boilerplate/js/default/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "tabWidth": 2,
+  "semi": false,
+  "printWidth": 100
+}

--- a/packages/create-blits/boilerplate/js/default/package.json
+++ b/packages/create-blits/boilerplate/js/default/package.json
@@ -5,11 +5,12 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "start": "npm run dev",
-    "lint": "eslint '**/*.js'",
-    "lint:fix": "eslint '**/*.js' --fix",
     "build": "vite build",
-    "dev": "vite dev --host"
+    "dev": "vite dev --host",
+    "format": "prettier --write .",
+    "lint": "eslint '**/*.?(c|m)[jt]s'",
+    "lint:fix": "eslint '**/*.?(c|m)[jt]s' --fix",
+    "start": "npm run dev"
   },
   "devDependencies": {
     "vite": "^5.4.8"

--- a/packages/create-blits/boilerplate/js/default/vite.config.js
+++ b/packages/create-blits/boilerplate/js/default/vite.config.js
@@ -1,12 +1,18 @@
 /// <reference types="vite/client" />
 
 import { defineConfig } from 'vite'
+// @ts-expect-error
 import blitsVitePlugins from '@lightningjs/blits/vite'
 
-export default defineConfig(({ command, mode, ssrBuild }) => {
+/** @type {NonNullable<import('vite').UserConfig['worker']>['format']} */
+const format = 'es'
+/** @type {import('vite').PluginOption} */
+const plugins = [...blitsVitePlugins]
+
+export default defineConfig(() => {
   return {
     base: '/', // Set to your base path if you are deploying to a subdirectory (example: /myApp/)
-    plugins: [...blitsVitePlugins],
+    plugins,
     resolve: {
       mainFields: ['browser', 'module', 'jsnext:main', 'jsnext'],
     },
@@ -20,7 +26,7 @@ export default defineConfig(({ command, mode, ssrBuild }) => {
       },
     },
     worker: {
-      format: 'es',
+      format,
     },
   }
 })

--- a/packages/create-blits/boilerplate/ts/default/.prettierrc
+++ b/packages/create-blits/boilerplate/ts/default/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "tabWidth": 2,
+  "semi": false,
+  "printWidth": 100
+}

--- a/packages/create-blits/boilerplate/ts/default/package.json
+++ b/packages/create-blits/boilerplate/ts/default/package.json
@@ -5,11 +5,12 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "start": "npm run dev",
-    "lint": "eslint '**/*.js'",
-    "lint:fix": "eslint '**/*.js' --fix",
     "build": "vite build",
-    "dev": "vite dev --host"
+    "dev": "vite dev --host",
+    "format": "prettier --write .",
+    "lint": "eslint '**/*.?(c|m)[jt]s'",
+    "lint:fix": "eslint '**/*.?(c|m)[jt]s' --fix",
+    "start": "npm run dev"
   },
   "devDependencies": {
     "vite": "^5.4.8",

--- a/packages/create-blits/boilerplate/ts/default/src/components/Loader.ts
+++ b/packages/create-blits/boilerplate/ts/default/src/components/Loader.ts
@@ -1,6 +1,5 @@
 import Blits from '@lightningjs/blits'
 
-
 export default Blits.Component('Loader', {
   template: `
     <Element>

--- a/packages/create-blits/boilerplate/ts/default/vite.config.js
+++ b/packages/create-blits/boilerplate/ts/default/vite.config.js
@@ -1,12 +1,18 @@
 /// <reference types="vite/client" />
 
 import { defineConfig } from 'vite'
+// @ts-expect-error
 import blitsVitePlugins from '@lightningjs/blits/vite'
 
-export default defineConfig(({ command, mode, ssrBuild }) => {
+/** @type {NonNullable<import('vite').UserConfig['worker']>['format']} */
+const format = 'es'
+/** @type {import('vite').PluginOption} */
+const plugins = [...blitsVitePlugins]
+
+export default defineConfig(() => {
   return {
     base: '/', // Set to your base path if you are deploying to a subdirectory (example: /myApp/)
-    plugins: [...blitsVitePlugins],
+    plugins,
     resolve: {
       mainFields: ['browser', 'module', 'jsnext:main', 'jsnext'],
     },
@@ -20,7 +26,7 @@ export default defineConfig(({ command, mode, ssrBuild }) => {
       },
     },
     worker: {
-      format: 'es',
+      format,
     },
   }
 })

--- a/packages/create-blits/package-lock.json
+++ b/packages/create-blits/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lightningjs/create-blits",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lightningjs/create-blits",
-      "version": "1.3.0",
+      "version": "1.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "execa": "^8.0.1",


### PR DESCRIPTION
These changes just improve the state of an app created via the npx script, including:

- updating globs to lint and format all js file variants;
- including a .prettierrc that makes prettier play nicely with the ESLint config;
- adding script and lint-staged command for prettier;
- ordering script commands alphabetically; and
- fixing type errors in the vite config file.