### PR TITLE
Add platform setting to launch configuration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1196,7 +1196,14 @@ declare module '@lightningjs/blits' {
      *
      * Defaults to `0` which means no maximum
      */
-    maxFPS?: number
+    maxFPS?: number,
+    /**
+     * Custom platform layer to be used by the App (experimental)
+     *
+     * Defaults to `null` which will be resolved internally to WebPlatform
+     */
+    platform?: any
+
   }
 
   interface State {

--- a/src/engines/L3/launch.js
+++ b/src/engines/L3/launch.js
@@ -100,7 +100,7 @@ export default (App, target, settings = {}) => {
         textureMemory: textureMemorySettings(settings),
         createImageBitmapSupport: 'auto',
         targetFPS: 'maxFPS' in settings ? settings.maxFPS : 0,
-        platform: settings.platform,
+        platform: 'platform' in settings ? settings.platform : null,
       },
       ...(settings.advanced || {}),
     },


### PR DESCRIPTION
Blits apps need to provide platform to the renderer