### PR TITLE
fix(#576): dont trigger parent layout when setting element prop

### DIFF
--- a/src/engines/L3/element.js
+++ b/src/engines/L3/element.js
@@ -642,10 +642,6 @@ const Element = {
         }
       }
     }
-
-    if (this.config.parent.props && this.config.parent.props.__layout === true) {
-      this.config.parent.triggerLayout(this.config.parent.props)
-    }
   },
   animate(prop, value, transition) {
     // check if a transition is already scheduled to run on the same prop


### PR DESCRIPTION
I'd be surprised if this was the best fix for this issue (I've really gone on a deep dive to try and find something better), but it does stop it from happening.  I'm nervous as to what might break by removing this, although I haven't seen any negative impacts yet.  I think part of the problem is I'm not entirely sure why it's there.  Why would changing a prop like `z` on a child element of a Layout require its dimensions to be recalculated?  This is the PR that introduced it, if that helps jog the memory 👉 #203 

Also, the same condition appears in other parts of this file (e.g. in the `animate` function).  I've not yet seen it act problematically in those areas but, again, I'm not sure why it's needed there either.

Closes #576 