### PR TITLE
Running Blits Tests in git pre push hook

### DIFF
--- a/scripts/prepush.js
+++ b/scripts/prepush.js
@@ -69,7 +69,6 @@ try {
   // Run ESLint on the changed files
   execSync(`npx eslint ${fileList.join(' ')}`, { stdio: 'inherit' })
   console.log('Linting passed successfully!\n')
-  process.exit(0)
 } catch (error) {
   console.log('\n==========================================================================')
   console.log('ESLint found issues in your code. Please fix them before pushing.')
@@ -78,4 +77,25 @@ try {
   console.log('on the specific files to automatically fix some issues.')
   console.log('==========================================================================\n')
   process.exit(1)
+}
+
+// By default, always run tests unless RUN_TEST=skip
+const runTestsFlag = process.env.RUN_TEST || ''
+
+if (runTestsFlag.toLowerCase() === 'skip') {
+  console.log('Skipping tests due to RUN_TEST=skip. Proceeding with push.')
+  process.exit(0)
+} else {
+  // For any other value (including empty or unknown), run tests
+  try {
+    console.log('Running tests...\n')
+    execSync('npm run test', { stdio: 'inherit' })
+    console.log('Tests passed successfully!\n')
+    process.exit(0)
+  } catch (error) {
+    console.log('\n==========================================================================')
+    console.log('Some tests failed. Please fix them before pushing.')
+    console.log('==========================================================================\n')
+    process.exit(1)
+  }
 }


### PR DESCRIPTION
By default blits tests will execute on git push command But one can skip executing blits tests by configuring environment variable RUN_TEST=skip

sh/bash
```sh RUN_TEST=skip git push (skips executing blits tests on push)```

powershell
```$env:RUN_TEST="skip"; git push```