### PR TITLE
fix(shaders): only normalize color in parseProps for border align/gap…

### DIFF
--- a/src/lib/shaders/shaders.js
+++ b/src/lib/shaders/shaders.js
@@ -139,11 +139,12 @@ export default {
       return v
     }
     if (typeof v === 'string') {
-      return colors.normalize(v)
+      return colors.normalize(v, v)
     }
     if (Array.isArray(v) === true) {
       return v.map((i) => this.parseProp(i))
     }
+    return v
   },
   parseProps(v) {
     if (typeof v === 'string') {
@@ -156,9 +157,7 @@ export default {
       if (key === 'type') {
         continue
       }
-      if (key === 'color') {
-        v[key] = this.parseProp(v[key])
-      }
+      v[key] = this.parseProp(v[key])
     }
     return v
   },


### PR DESCRIPTION
Fix v2 border align/gap on reactive updates by only normalizing the color key in parseProps so non-color strings (e.g. align: 'outside') are passed through to the renderer.