### PR TITLE
reactivity guard: adds `&&` chaining for injected variables

### DIFF
--- a/src/lib/reactivityguard/computedprops.js
+++ b/src/lib/reactivityguard/computedprops.js
@@ -196,14 +196,19 @@ export default (code) => {
             // Skip if already modified
             if (
               prop.body.includes(commentText.trim()) ||
-              Array.from(thisRefs).some((ref) => prop.body.startsWith(ref))
+              Array.from(thisRefs).some((ref) => {
+                if (prop.body.startsWith(ref)) return true
+                // stripped && guard: body starts with the first segment, e.g. 'this.media &&'
+                const firstSegEnd = ref.indexOf('.', 5)
+                return firstSegEnd !== -1 && prop.body.startsWith(ref.substring(0, firstSegEnd))
+              })
             ) {
               continue
             }
 
             // reactivity code
             const refCode = Array.from(thisRefs)
-              .map((ref) => `${ref};`)
+              .map((ref) => `${toSafeRef(ref)};`)
               .join(' ')
 
             // replacement with the same whitespace
@@ -288,6 +293,18 @@ export default (code) => {
   }
 
   return null
+}
+
+const toSafeRef = (ref) => {
+  // Converts 'this.a.b.c' to 'this.a && this.a.b && this.a.b.c'
+  const normalized = ref.replace(/\?\./g, '.')
+  const segments = normalized.split('.')
+  if (segments.length <= 2) return normalized
+  const parts = []
+  for (let i = 2; i <= segments.length; i++) {
+    parts.push(segments.slice(0, i).join('.'))
+  }
+  return parts.join(' && ')
 }
 
 const extractThisReferences = (funcBody) => {

--- a/src/lib/reactivityguard/computedprops.test.js
+++ b/src/lib/reactivityguard/computedprops.test.js
@@ -135,10 +135,77 @@ test('Guards full property chain for nested reactive references', (assert) => {
   const result = processComputedProps(input)
   assert.ok(result, 'injects guards')
   const out = result.code
-  assert.ok(out.includes('this.$appState.ui.sidebar;'), 'guards full chain')
-  assert.ok(out.includes('this.item.tags;'), 'stops chain before method call')
-  assert.notOk(out.includes('this.$appState;'), 'no redundant prefix this.$appState')
-  assert.notOk(out.includes('this.item;'), 'no redundant prefix this.item')
+  assert.ok(
+    out.includes('this.$appState && this.$appState.ui && this.$appState.ui.sidebar;'),
+    'guards full chain with &&'
+  )
+  assert.ok(out.includes('this.item && this.item.tags;'), 'stops chain before method call')
+  assert.notOk(out.includes('this.$appState;'), 'no standalone this.$appState guard')
+  assert.notOk(out.includes('this.item;'), 'no standalone this.item guard')
+  assert.end()
+})
+
+test('Guards deep chain with && when intermediate values can be null', (assert) => {
+  const input = `
+    import Blits from '@lightningjs/blits'
+    export default Blits.Component('C', {
+      computed: {
+        posterUrl() {
+          if (!this.media) return null
+          return this.media.poster.src
+        },
+      }
+    })
+  `
+
+  assert.doesNotThrow(() => processComputedProps(input), 'should not throw')
+  const result = processComputedProps(input)
+  assert.ok(result, 'injects guards')
+  const out = result.code
+  assert.ok(
+    out.includes('this.media && this.media.poster && this.media.poster.src;'),
+    'injects full && chain'
+  )
+  assert.end()
+})
+
+test('Does not duplicate guards when && guard comment is stripped', (assert) => {
+  const alreadyGuarded = `
+    import Blits from '@lightningjs/blits'
+    export default Blits.Component('C', {
+      computed: {
+        posterUrl() {
+          this.media && this.media.poster && this.media.poster.src;
+          if (!this.media) return null
+          return this.media.poster.src
+        },
+      }
+    })
+  `
+
+  const result = processComputedProps(alreadyGuarded)
+  assert.equal(result, null, 'should return null when && guard already present')
+  assert.end()
+})
+
+test('Single-level ref guard has no && chain', (assert) => {
+  const input = `
+    import Blits from '@lightningjs/blits'
+    export default Blits.Component('C', {
+      computed: {
+        label() {
+          return this.title || 'fallback'
+        },
+      }
+    })
+  `
+
+  assert.doesNotThrow(() => processComputedProps(input), 'should not throw')
+  const result = processComputedProps(input)
+  assert.ok(result, 'injects guards')
+  const out = result.code
+  assert.ok(out.includes('this.title;'), 'single-level ref injected as-is')
+  assert.notOk(out.includes('&&'), 'no && for single-level ref')
   assert.end()
 })
 


### PR DESCRIPTION
Computed properties with null/undefined guards were crashing at runtime because the injected guard expression (e.g. `this.foo.bar;`) runs before the user's own null checks and throws error when intermediate values are absent.

Variables are now injected as a `&&` chain: `this.foo && this.foo.bar;`. 