### PR TITLE
Fixes rounded prop not updating when value is an array

### DIFF
--- a/src/engines/L3/element.js
+++ b/src/engines/L3/element.js
@@ -362,7 +362,10 @@ const propsTransformer = {
   set rounded(v) {
     this.props['rounded'] = v
     if (this.element.node !== undefined && this.elementShader === true) {
-      if (typeof v === 'object' || (isObjectString(v) === true && (v = parseToObject(v)))) {
+      if (
+        !Array.isArray(v) &&
+        (typeof v === 'object' || (isObjectString(v) === true && (v = parseToObject(v))))
+      ) {
         this.element.node.props['shader'].props = v
       } else {
         if (isArrayString(v) === true) {

--- a/src/engines/L3/element.js
+++ b/src/engines/L3/element.js
@@ -363,7 +363,7 @@ const propsTransformer = {
     this.props['rounded'] = v
     if (this.element.node !== undefined && this.elementShader === true) {
       if (
-        !Array.isArray(v) &&
+        Array.isArray(v) === false &&
         (typeof v === 'object' || (isObjectString(v) === true && (v = parseToObject(v))))
       ) {
         this.element.node.props['shader'].props = v

--- a/src/engines/L3/element.test.js
+++ b/src/engines/L3/element.test.js
@@ -1106,6 +1106,27 @@ test('Element - ElementShader with rounded', (assert) => {
   assert.end()
 })
 
+test('Element - Update rounded with array sets radius', (assert) => {
+  const shaderProps = { radius: 0 }
+  const mockNode = Object.assign(new EventEmitter(), {
+    props: { shader: { props: shaderProps } },
+  })
+  assert.capture(renderer, 'createNode', () => mockNode)
+  const el = element({ parent: { node: { w: 1920, h: 1080 } } }, {})
+  el.populate({ parent: { node: new EventEmitter() }, rounded: 10 })
+  el.set('rounded', [40, 40, 10, 10])
+  assert.deepEqual(
+    el.node.props['shader'].props.radius,
+    [40, 40, 10, 10],
+    'radius should be updated to the new array'
+  )
+  assert.notOk(
+    Array.isArray(el.node.props['shader'].props),
+    'shader props should remain an object, not be replaced by the array'
+  )
+  assert.end()
+})
+
 test('Element - ElementShader with border', (assert) => {
   assert.capture(renderer, 'createNode', () => new EventEmitter())
   const el = element({ parent: { node: { w: 1920, h: 1080 } } }, {})


### PR DESCRIPTION
When `rounded` is set to an array and then updated reactively, the corners weren't changing. The setter was using `typeof v === 'object'` to detect plain objects, but arrays are also objects, array values were going to the wrong `if` branch. 

Added a simple `!Array.isArray(v)` to the condition so arrays are handled correctly. Also added a test about this situation.