### PR TITLE
create internal keyb event to work around browser issues

### DIFF
--- a/src/focus/focus.js
+++ b/src/focus/focus.js
@@ -21,6 +21,7 @@ import Settings from '../settings.js'
 import { DEFAULT_HOLD_TIMEOUT_MS } from '../constants.js'
 import { Log } from '../lib/log.js'
 import { getAncestors } from './helpers.js'
+import InternalKeyboardEvent from '../lib/events/internalkeyboardevent.js'
 
 let focusedComponent = null
 let focusChain = []
@@ -133,9 +134,7 @@ const setFocus = (component, event) => {
   component[symbols.lifecycle].state = 'focus'
 
   if (event instanceof KeyboardEvent) {
-    const internalEvent = new KeyboardEvent('keydown', event)
-    // @ts-ignore - this is an internal event
-    internalEvent[symbols.internalEvent] = true
+    const internalEvent = new InternalKeyboardEvent('keydown', event)
     document.dispatchEvent(internalEvent)
   }
 }

--- a/src/lib/events/internalkeyboardevent.js
+++ b/src/lib/events/internalkeyboardevent.js
@@ -1,0 +1,36 @@
+import symbols from '../symbols'
+
+/**
+ * Internal keyboard event class that extends the native KeyboardEvent.
+ * This allows us to set props on the event from the eventInitDict,
+ * which is not correctly implemented on some browsers.
+ *
+ * @extends {KeyboardEvent}
+ */
+export default class InternalKeyboardEvent extends KeyboardEvent {
+  [symbols.internalEvent] = true
+  _keyCode = 0
+
+  get keyCode() {
+    return this._keyCode
+  }
+
+  /**
+   * @param {number} value
+   */
+  set keyCode(value) {
+    this._keyCode = value
+  }
+
+  /**
+   * @param {string} type - A string with the name of the event
+   * @param {KeyboardEventInit} [eventInitDict] - An object that configures the event
+   */
+  constructor(type, eventInitDict) {
+    super(type, eventInitDict)
+
+    if ('keyCode' in eventInitDict) {
+      this.keyCode = eventInitDict.keyCode
+    }
+  }
+}

--- a/src/lib/events/internalkeyboardevent.js
+++ b/src/lib/events/internalkeyboardevent.js
@@ -16,13 +16,6 @@ export default class InternalKeyboardEvent extends KeyboardEvent {
   }
 
   /**
-   * @param {number} value
-   */
-  set keyCode(value) {
-    this._keyCode = value
-  }
-
-  /**
    * @param {string} type - A string with the name of the event
    * @param {KeyboardEventInit} [eventInitDict] - An object that configures the event
    */
@@ -30,7 +23,7 @@ export default class InternalKeyboardEvent extends KeyboardEvent {
     super(type, eventInitDict)
 
     if ('keyCode' in eventInitDict) {
-      this.keyCode = eventInitDict.keyCode
+      this._keyCode = eventInitDict.keyCode
     }
   }
 }


### PR DESCRIPTION
Some of the finer STBs that Blits is currently running on in production are running chrome 56, where there appears to be a bug with KeyboardEvent where the constructor doesn't apply many of the options provided in the 2nd argument, including `keyCode`, which Blits relies on internally.

This PR introduces a workaround class that extends KeyboardEvent and ensures the `keyCode` supplied in the constructor is applied.  Other props can be added as needed.