### PR TITLE
Replaced leftover keyboard event code events with keyCode.

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -118,9 +118,9 @@ const Application = (config) => {
     }
 
     keyUpHandler = (e) => {
-      const cb = keyUpCallbacks.get(e.code)
+      const cb = keyUpCallbacks.get(e.keyCode)
       if (cb !== undefined && typeof cb === 'function') {
-        keyUpCallbacks.delete(e.code)
+        keyUpCallbacks.delete(e.keyCode)
         cb()
       }
       clearTimeout(holdTimeout)

--- a/src/component/base/methods.js
+++ b/src/component/base/methods.js
@@ -51,7 +51,7 @@ export default {
       if (event === null || event === undefined || event instanceof KeyboardEvent === false)
         return false
 
-      const key = keyMap[event.key] || keyMap[event.keyCode] || event.key || event.keyCode
+      const key = keyMap[event.keyCode] || event.keyCode
 
       const componentWithInputEvent = getComponentWithInputEvent(this, key)
       if (componentWithInputEvent === null) return false
@@ -65,8 +65,8 @@ export default {
         cb = inputEvents.any.call(componentWithInputEvent, event)
       }
 
-      if (cb !== undefined && event.code) {
-        keyUpCallbacks.set(event.code, cb)
+      if (cb !== undefined && event.keyCode) {
+        keyUpCallbacks.set(event.keyCode, cb)
       }
 
       return true

--- a/src/focus/focus.js
+++ b/src/focus/focus.js
@@ -95,7 +95,7 @@ export default {
     }
 
     if (cb !== undefined) {
-      keyUpCallbacks.set(event.code, cb)
+      keyUpCallbacks.set(event.keyCode, cb)
     }
   },
 }


### PR DESCRIPTION
`KeyboardEvent.code` has been replaced by `KeyboardEvent.keyCode` in Blits v2, and there were some left over instances of `code`