### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ _23 mar 2026_
 - Fixed issue with height dimension of router view
 - Fixed issue with array or rounded corners not being reactive
 - Fixed issue with font not being mapped correctly when using `png` in the font config
-- Removed obselete key config
+- Removed obsolete key config
 - Fixed reactivity guard in computed props to handle deep nested references more safely
 
 ## v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v2.1.0
+
+_9 apr 2026_
+
+- Fixed left over `KeyboardEvent.code` references
+- Fixed issue with allowing $-prefix to be used as text content
+- Fixed issue with internal keyboard event not working on older browsers
+- Added tests to router hooks
+- Fixed issue with transitions not being skipped when duration is set to `0`
+- Added `this.$nextTick` utility helper
+- Fixed issue with transitioning colours in `border`-attribute
+
 ## v2.0.1
 
 _23 mar 2026_

--- a/index.d.ts
+++ b/index.d.ts
@@ -475,6 +475,13 @@ declare module '@lightningjs/blits' {
     $clearDebounces: () => void
 
     /**
+    * Defer a callback to the next tick (setTimeout 0), automatically cleaned upon component destroy
+    * @param callback - Function to execute on the next tick
+    * @param args - Arguments to pass to the callback
+    */
+    $nextTick: (callback: (...args: any[]) => void, ...args: any[]) => ReturnType<typeof setTimeout>
+
+    /**
     * Set an interval that is automatically cleaned upon component destroy
     */
     $setInterval: (callback: (args: any) => void, ms?: number | undefined) => ReturnType<typeof setInterval>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lightningjs/blits",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lightningjs/blits",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@lightningjs/renderer": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightningjs/blits",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Blits: The Lightning 3 App Development Framework",
   "bin": "bin/index.js",
   "exports": {

--- a/src/application.js
+++ b/src/application.js
@@ -118,9 +118,9 @@ const Application = (config) => {
     }
 
     keyUpHandler = (e) => {
-      const cb = keyUpCallbacks.get(e.code)
+      const cb = keyUpCallbacks.get(e.keyCode)
       if (cb !== undefined && typeof cb === 'function') {
-        keyUpCallbacks.delete(e.code)
+        keyUpCallbacks.delete(e.keyCode)
         cb()
       }
       clearTimeout(holdTimeout)

--- a/src/component/base/methods.js
+++ b/src/component/base/methods.js
@@ -51,7 +51,7 @@ export default {
       if (event === null || event === undefined || event instanceof KeyboardEvent === false)
         return false
 
-      const key = keyMap[event.key] || keyMap[event.keyCode] || event.key || event.keyCode
+      const key = keyMap[event.keyCode] || event.keyCode
 
       const componentWithInputEvent = getComponentWithInputEvent(this, key)
       if (componentWithInputEvent === null) return false
@@ -65,8 +65,8 @@ export default {
         cb = inputEvents.any.call(componentWithInputEvent, event)
       }
 
-      if (cb !== undefined && event.code) {
-        keyUpCallbacks.set(event.code, cb)
+      if (cb !== undefined && event.keyCode) {
+        keyUpCallbacks.set(event.keyCode, cb)
       }
 
       return true

--- a/src/component/base/timeouts_intervals.js
+++ b/src/component/base/timeouts_intervals.js
@@ -152,4 +152,14 @@ export default {
     enumerable: true,
     configurable: false,
   },
+  $nextTick: {
+    value: function (fn, ...params) {
+      // early exit when component is marked as end of life
+      if (this.eol === true) return
+      return this.$setTimeout(fn, 0, ...params)
+    },
+    writable: false,
+    enumerable: true,
+    configurable: false,
+  },
 }

--- a/src/component/base/timeouts_intervals.test.js
+++ b/src/component/base/timeouts_intervals.test.js
@@ -476,3 +476,67 @@ test('$debounce method with zero delay', (assert) => {
     assert.end()
   }, 10)
 })
+
+test('$nextTick method', (assert) => {
+  const component = createComponent()
+  let called = false
+
+  const result = timeoutsIntervals.$nextTick.value.call(component, () => {
+    called = true
+  })
+
+  assert.ok(result !== undefined, 'Should return a timeout ID')
+  assert.equal(component[symbols.timeouts].length, 1, 'Should add timeout to array')
+
+  setTimeout(() => {
+    assert.ok(called, 'Callback should execute on next tick')
+    assert.end()
+  }, 50)
+})
+
+test('$nextTick method when eol is true', (assert) => {
+  const component = createComponent(true)
+
+  const result = timeoutsIntervals.$nextTick.value.call(component, () => {})
+
+  assert.equal(result, undefined, 'Should return undefined when eol is true')
+  assert.equal(component[symbols.timeouts].length, 0, 'Should not add timeout when eol is true')
+  assert.end()
+})
+
+test('$nextTick method with parameters', (assert) => {
+  const component = createComponent()
+  let receivedParams = null
+
+  timeoutsIntervals.$nextTick.value.call(
+    component,
+    (param1, param2) => {
+      receivedParams = [param1, param2]
+    },
+    'value1',
+    'value2'
+  )
+
+  setTimeout(() => {
+    assert.deepEqual(receivedParams, ['value1', 'value2'], 'Should pass parameters correctly')
+    assert.end()
+  }, 50)
+})
+
+test('$nextTick method is cleaned up by $clearTimeouts', (assert) => {
+  const component = createComponent()
+  let called = false
+
+  timeoutsIntervals.$nextTick.value.call(component, () => {
+    called = true
+  })
+
+  assert.equal(component[symbols.timeouts].length, 1, 'Should track the timeout')
+  timeoutsIntervals.$clearTimeouts.value.call(component)
+  assert.equal(component[symbols.timeouts].length, 0, 'Should be cleared by $clearTimeouts')
+
+  setTimeout(() => {
+    assert.false(called, 'Callback should not execute after clearTimeouts')
+    assert.end()
+  }, 50)
+})

--- a/src/engines/L3/element.js
+++ b/src/engines/L3/element.js
@@ -377,14 +377,17 @@ const propsTransformer = {
   },
   set border(v) {
     this.props['border'] = v
+
     if (
       this.element.node !== undefined &&
       this.elementShader === true &&
       (typeof v === 'object' || isObjectString(v) === true)
     ) {
       v = shaders.parseProps(v)
+      const shader = this.element.node.props['shader']
+      let prefix = shader.shaderKey.startsWith('rounded') ? 'border-' : ''
       for (const key in v) {
-        this.element.node.props['shader'].props[`border-${key}`] = v[key]
+        this.element.node.props['shader'].props[prefix + key] = v[key]
       }
     }
   },
@@ -396,8 +399,10 @@ const propsTransformer = {
       (typeof v === 'object' || isObjectString(v) === true)
     ) {
       v = shaders.parseProps(v)
+      const shader = this.element.node.props['shader']
+      let prefix = shader.shaderKey.startsWith('rounded') ? 'shadow-' : ''
       for (const key in v) {
-        this.element.node.props['shader'].props[`shadow-${key}`] = v[key]
+        this.element.node.props['shader'].props[prefix + key] = v[key]
       }
     }
   },

--- a/src/engines/L3/element.js
+++ b/src/engines/L3/element.js
@@ -16,7 +16,13 @@
  */
 
 import { renderer } from './launch.js'
-import { parseToObject, isObjectString, isArrayString, isTransition } from '../../lib/utils.js'
+import {
+  parseToObject,
+  isObjectString,
+  isArrayString,
+  isTransition,
+  isZeroDurationTransition,
+} from '../../lib/utils.js'
 import colors from '../../lib/colors/colors.js'
 
 import { Log } from '../../lib/log.js'
@@ -668,7 +674,7 @@ const Element = {
     const propsKeys = Object.keys(this.props.props)
 
     if (propsKeys.length === 1) {
-      if (isTransition(value) === true) {
+      if (isTransition(value) === true && isZeroDurationTransition(value) === false) {
         return this.animate(propsKeys[0], this.props.props[propsKeys[0]], value.transition)
       }
       // set the prop to the value on the node
@@ -676,7 +682,7 @@ const Element = {
     } else {
       for (let i = 0; i < propsKeys.length; i++) {
         // todo: fix code duplication
-        if (isTransition(value) === true) {
+        if (isTransition(value) === true && isZeroDurationTransition(value) === false) {
           this.animate(propsKeys[i], this.props.props[propsKeys[i]], value.transition)
         } else {
           // set the prop to the value on the node

--- a/src/engines/L3/element.test.js
+++ b/src/engines/L3/element.test.js
@@ -914,6 +914,70 @@ test('Element - Transition an element property with end callback', (assert) => {
   assert.end()
 })
 
+test('Element - Zero duration transition sets value directly without animating', (assert) => {
+  const customNode = new CustomNode()
+  assert.capture(renderer, 'createNode', () => customNode)
+  const el = createElement()
+
+  const animateSpy = sinon.spy(customNode, 'animate')
+
+  el.set('w', { transition: { value: 200, duration: 0 } })
+
+  assert.equal(el.props.props['w'], 200, 'Props w parameter should be set to 200')
+  assert.equal(customNode.w, 200, 'Node w should be set directly to 200')
+  assert.equal(animateSpy.callCount, 0, 'animate should not be called for zero duration transition')
+
+  animateSpy.restore()
+  assert.end()
+})
+
+test('Element - Zero duration transition on multiple properties sets values directly', (assert) => {
+  const customNode = new CustomNode()
+  assert.capture(renderer, 'createNode', () => customNode)
+  const el = createElement()
+
+  const animateSpy = sinon.spy(customNode, 'animate')
+
+  el.set('x', { transition: { value: 50, duration: 0 } })
+  el.set('y', { transition: { value: 75, duration: 0 } })
+
+  assert.equal(customNode.x, 50, 'Node x should be set directly to 50')
+  assert.equal(customNode.y, 75, 'Node y should be set directly to 75')
+  assert.equal(
+    animateSpy.callCount,
+    0,
+    'animate should not be called for any zero duration transition'
+  )
+
+  animateSpy.restore()
+  assert.end()
+})
+
+test('Element - Non-zero duration transition calls animate', (assert) => {
+  const customNode = new CustomNode()
+  assert.capture(renderer, 'createNode', () => customNode)
+  const el = createElement()
+
+  const animateSpy = sinon.spy(customNode, 'animate')
+
+  el.set('w', { transition: { value: 300, duration: 500 } })
+
+  assert.equal(el.props.props['w'], 300, 'Props w parameter should be set to 300')
+  assert.equal(animateSpy.callCount, 0, 'animate is debounced via setTimeout(0)')
+
+  setTimeout(() => {
+    assert.equal(
+      animateSpy.callCount,
+      1,
+      'animate should be called once for non-zero duration transition'
+    )
+    assert.equal(customNode.w, 300, 'Node w should be set to 300 after animation')
+
+    animateSpy.restore()
+    assert.end()
+  }, 1000)
+})
+
 test('Element - Destroy created Element node', (assert) => {
   assert.capture(renderer, 'createNode', () => new CustomNode())
   const el = createElement()

--- a/src/focus/focus.js
+++ b/src/focus/focus.js
@@ -95,7 +95,7 @@ export default {
     }
 
     if (cb !== undefined) {
-      keyUpCallbacks.set(event.code, cb)
+      keyUpCallbacks.set(event.keyCode, cb)
     }
   },
 }

--- a/src/focus/focus.js
+++ b/src/focus/focus.js
@@ -21,6 +21,7 @@ import Settings from '../settings.js'
 import { DEFAULT_HOLD_TIMEOUT_MS } from '../constants.js'
 import { Log } from '../lib/log.js'
 import { getAncestors } from './helpers.js'
+import InternalKeyboardEvent from '../lib/events/internalkeyboardevent.js'
 
 let focusedComponent = null
 let focusChain = []
@@ -133,9 +134,7 @@ const setFocus = (component, event) => {
   component[symbols.lifecycle].state = 'focus'
 
   if (event instanceof KeyboardEvent) {
-    const internalEvent = new KeyboardEvent('keydown', event)
-    // @ts-ignore - this is an internal event
-    internalEvent[symbols.internalEvent] = true
+    const internalEvent = new InternalKeyboardEvent('keydown', event)
     document.dispatchEvent(internalEvent)
   }
 }

--- a/src/lib/codegenerator/generator.js
+++ b/src/lib/codegenerator/generator.js
@@ -116,7 +116,29 @@ export default function (templateObject = { children: [] }, devMode = false) {
 }
 
 // This is used to get only variable from expression
-const extractVariables = function (value) {
+const extractVariables = function (value, isContentKey = false) {
+  if (isContentKey) {
+    // Strip string literals (single and double quoted) so that $variables
+    // embedded in plain text (e.g. "'this.$notifications.add()'") are not
+    // mistakenly extracted as component variable references.
+    const stripped = value.replace(/'[^']*'|"[^"]*"/g, '')
+
+    // A $variable is a real component reference only if:
+    // 1. The value starts with a bare $variable (e.g. "$notification.add(ms,)")
+    // 2. The stripped text contains string concatenation (e.g. "'Count: ' + $notifications.count")
+    // Plain text with embedded $variables (e.g. "Custom plugin with $reactive state")
+    // should not trigger verification.
+    const isBareDollarVar = /^\s*\$\$?\w+/.test(stripped)
+    const hasConcatExpression = /\+/.test(stripped)
+    console.log(
+      `isBareDollarVar: ${isBareDollarVar}, hasConcatExpression: ${hasConcatExpression}, stripped: ${stripped}`
+    )
+    if (!isBareDollarVar && !hasConcatExpression) {
+      return false
+    }
+    value = stripped
+  }
+
   const regEx = /\$\$?\w+(\.\w+)?/g
   const matches = value.match(regEx)
   if (matches !== null) {
@@ -127,8 +149,8 @@ const extractVariables = function (value) {
   }
 }
 
-const verifyVariables = function (value, renderCode, type = 'dynamic') {
-  const variablesToBeVerified = extractVariables(value)
+const verifyVariables = function (value, renderCode, isContentKey = false, type = 'dynamic') {
+  const variablesToBeVerified = extractVariables(value, isContentKey)
   if (variablesToBeVerified !== false) {
     for (let i = 0; i < variablesToBeVerified.length; i++) {
       let variable = variablesToBeVerified[i]
@@ -222,7 +244,7 @@ const generateElementCode = function (
       }
       // value.includes('.') === false &&
       if (isDev === true && options.component !== 'scope.' && value.includes('$')) {
-        verifyVariables(value, renderCode, 'reactive')
+        verifyVariables(value, renderCode, key === ':content', 'reactive')
       }
       renderCode.push(
         `elementConfigs[${counter}]['${key.substring(1)}'] = ${interpolate(
@@ -232,7 +254,7 @@ const generateElementCode = function (
       )
     } else {
       if (isDev === true && options.component !== 'scope.' && value.includes('$')) {
-        verifyVariables(value, renderCode)
+        verifyVariables(value, renderCode, key === 'content')
       }
       renderCode.push(
         `elementConfigs[${counter}]['${key}'] = ${cast(value, key, options.component)}`

--- a/src/lib/codegenerator/generator.js
+++ b/src/lib/codegenerator/generator.js
@@ -130,9 +130,7 @@ const extractVariables = function (value, isContentKey = false) {
     // should not trigger verification.
     const isBareDollarVar = /^\s*\$\$?\w+/.test(stripped)
     const hasConcatExpression = /\+/.test(stripped)
-    console.log(
-      `isBareDollarVar: ${isBareDollarVar}, hasConcatExpression: ${hasConcatExpression}, stripped: ${stripped}`
-    )
+
     if (!isBareDollarVar && !hasConcatExpression) {
       return false
     }

--- a/src/lib/codegenerator/generator.test.js
+++ b/src/lib/codegenerator/generator.test.js
@@ -5249,3 +5249,92 @@ test('Generate code for a template with verification of attributes with Math cal
 
   assert.end()
 })
+
+test('Verify variables skips $variables inside string literals in static attributes', (assert) => {
+  const templateObject = {
+    children: [
+      {
+        [Symbol.for('componentType')]: 'Element',
+        content: 'Any component can call this.$notifications.add(msg, type)',
+      },
+    ],
+  }
+
+  const actual = generator.call(scope, templateObject, true)
+  const rendered = normalize(actual.render.toString())
+
+  assert.false(
+    rendered.includes("propInComponent('notifications.add"),
+    'Should NOT verify $notifications when inside string literal'
+  )
+
+  assert.end()
+})
+
+test('Verify variables extracts $variables in expression with string concat', (assert) => {
+  const templateObject = {
+    children: [
+      {
+        [Symbol.for('componentType')]: 'Element',
+        content: "'Sample' + $notification.add",
+      },
+    ],
+  }
+
+  const actual = generator.call(scope, templateObject, true)
+  const rendered = normalize(actual.render.toString())
+
+  assert.true(
+    rendered.includes("propInComponent('notification.add','dynamic')"),
+    'Should verify $notification.add when in expression with +'
+  )
+
+  assert.end()
+})
+
+test('Verify variables extracts plugins varibles outside string literals', (assert) => {
+  const templateObject = {
+    children: [
+      {
+        [Symbol.for('componentType')]: 'Element',
+        content: '$$notification.count',
+      },
+    ],
+  }
+
+  const actual = generator.call(scope, templateObject, true)
+  const rendered = normalize(actual.render.toString())
+
+  assert.false(
+    rendered.includes("propInComponent('zero"),
+    'Should NOT verify $zero inside string literal'
+  )
+  assert.true(
+    rendered.includes("propInComponent('$notification.count','dynamic')"),
+    'Should verify $notification.count when in expression with +'
+  )
+
+  assert.end()
+})
+
+test.only('Verify variables skips $variables in plain text without expressions', (assert) => {
+  const templateObject = {
+    children: [
+      {
+        [Symbol.for('componentType')]: 'Element',
+        content: '$$notifications.count, .items, .lastMessage update the template automatically',
+      },
+    ],
+  }
+
+  const actual = generator.call(scope, templateObject, true)
+  const rendered = normalize(actual.render.toString())
+  console.log(rendered)
+
+  assert.false(
+    rendered.includes("propInComponent('reactive"),
+    'Should NOT verify $reactive when embedded in plain text'
+  )
+
+  assert.end()
+})

--- a/src/lib/codegenerator/generator.test.js
+++ b/src/lib/codegenerator/generator.test.js
@@ -5317,19 +5317,18 @@ test('Verify variables extracts plugins varibles outside string literals', (asse
   assert.end()
 })
 
-test.only('Verify variables skips $variables in plain text without expressions', (assert) => {
+test('Verify variables skips $variables in plain text without expressions', (assert) => {
   const templateObject = {
     children: [
       {
         [Symbol.for('componentType')]: 'Element',
-        content: '$$notifications.count, .items, .lastMessage update the template automatically',
+        content: 'Custom plugin with $reactive state — all values update automatically',
       },
     ],
   }
 
   const actual = generator.call(scope, templateObject, true)
   const rendered = normalize(actual.render.toString())
-  console.log(rendered)
 
   assert.false(
     rendered.includes("propInComponent('reactive"),

--- a/src/lib/events/internalkeyboardevent.js
+++ b/src/lib/events/internalkeyboardevent.js
@@ -1,0 +1,36 @@
+import symbols from '../symbols'
+
+/**
+ * Internal keyboard event class that extends the native KeyboardEvent.
+ * This allows us to set props on the event from the eventInitDict,
+ * which is not correctly implemented on some browsers.
+ *
+ * @extends {KeyboardEvent}
+ */
+export default class InternalKeyboardEvent extends KeyboardEvent {
+  [symbols.internalEvent] = true
+  _keyCode = 0
+
+  get keyCode() {
+    return this._keyCode
+  }
+
+  /**
+   * @param {number} value
+   */
+  set keyCode(value) {
+    this._keyCode = value
+  }
+
+  /**
+   * @param {string} type - A string with the name of the event
+   * @param {KeyboardEventInit} [eventInitDict] - An object that configures the event
+   */
+  constructor(type, eventInitDict) {
+    super(type, eventInitDict)
+
+    if ('keyCode' in eventInitDict) {
+      this.keyCode = eventInitDict.keyCode
+    }
+  }
+}

--- a/src/lib/events/internalkeyboardevent.js
+++ b/src/lib/events/internalkeyboardevent.js
@@ -16,13 +16,6 @@ export default class InternalKeyboardEvent extends KeyboardEvent {
   }
 
   /**
-   * @param {number} value
-   */
-  set keyCode(value) {
-    this._keyCode = value
-  }
-
-  /**
    * @param {string} type - A string with the name of the event
    * @param {KeyboardEventInit} [eventInitDict] - An object that configures the event
    */
@@ -30,7 +23,7 @@ export default class InternalKeyboardEvent extends KeyboardEvent {
     super(type, eventInitDict)
 
     if ('keyCode' in eventInitDict) {
-      this.keyCode = eventInitDict.keyCode
+      this._keyCode = eventInitDict.keyCode
     }
   }
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -53,6 +53,15 @@ export const isTransition = (value) => {
 }
 
 /**
+ * Checks if a transition object has a duration of zero.
+ * @param {any} value - The value to check.
+ * @returns {boolean} True if the transition duration is zero, false otherwise.
+ */
+export const isZeroDurationTransition = (value) => {
+  return value.transition.duration === 0
+}
+
+/**
  * Checks if a string is an object string (starts and ends with curly braces).
  * @param {string} str - The string to check.
  * @returns {boolean} True if the string is an object string, false otherwise.

--- a/src/router/router.test.js
+++ b/src/router/router.test.js
@@ -37,6 +37,7 @@ const mockComponents = {
   CatchAll: () => {},
 }
 
+// matchHash is typed as Route[]; fixtures are partial configs like real route tables.
 const routes = /** @type {import('./router.js').Route[]} */ (
   /** @type {unknown} */ ([
     {

--- a/src/router/router.test.js
+++ b/src/router/router.test.js
@@ -37,48 +37,50 @@ const mockComponents = {
   CatchAll: () => {},
 }
 
-const routes = [
-  {
-    path: '/',
-    component: mockComponents.Home,
-  },
-  {
-    path: '/page1',
-    component: mockComponents.Page1,
-  },
-  {
-    path: '/page1/subpage1',
-    component: mockComponents.SubPage1,
-  },
-  {
-    path: '/tv/:show/seasons/:season',
-    component: mockComponents.Season,
-  },
-  {
-    path: '/movies/special',
-    component: mockComponents.Special,
-  },
-  {
-    path: '/movies/:name',
-    component: mockComponents.Movie,
-  },
-  {
-    path: '/examples/*',
-    component: mockComponents.ExampleCatchAll,
-  },
-  {
-    path: '/route/with/trailing/slash/',
-    component: mockComponents.Slash,
-  },
-  {
-    path: '/dutchmovies/:id',
-    component: mockComponents.DutchMovies,
-  },
-  {
-    path: '*',
-    component: mockComponents.CatchAll,
-  },
-]
+const routes = /** @type {import('./router.js').Route[]} */ (
+  /** @type {unknown} */ ([
+    {
+      path: '/',
+      component: mockComponents.Home,
+    },
+    {
+      path: '/page1',
+      component: mockComponents.Page1,
+    },
+    {
+      path: '/page1/subpage1',
+      component: mockComponents.SubPage1,
+    },
+    {
+      path: '/tv/:show/seasons/:season',
+      component: mockComponents.Season,
+    },
+    {
+      path: '/movies/special',
+      component: mockComponents.Special,
+    },
+    {
+      path: '/movies/:name',
+      component: mockComponents.Movie,
+    },
+    {
+      path: '/examples/*',
+      component: mockComponents.ExampleCatchAll,
+    },
+    {
+      path: '/route/with/trailing/slash/',
+      component: mockComponents.Slash,
+    },
+    {
+      path: '/dutchmovies/:id',
+      component: mockComponents.DutchMovies,
+    },
+    {
+      path: '*',
+      component: mockComponents.CatchAll,
+    },
+  ])
+)
 
 test('Type of matchHash', (assert) => {
   const expected = 'function'
@@ -895,10 +897,12 @@ test('keepAlive override does not bleed into the destination route options', asy
     code: { render: () => ({ elms: [], cleanup: () => {} }), effects: [] },
   })
 
-  const routesList = [
-    { path: '/srcA', component: PageA, options: { inHistory: true, passFocus: false } },
-    { path: '/srcB', component: PageB, options: { inHistory: true, passFocus: false } },
-  ]
+  const routesList = /** @type {import('./router.js').Route[]} */ (
+    /** @type {unknown} */ ([
+      { path: '/srcA', component: PageA, options: { inHistory: true, passFocus: false } },
+      { path: '/srcB', component: PageB, options: { inHistory: true, passFocus: false } },
+    ])
+  )
 
   const host = {
     [symbols.parent]: {
@@ -1059,6 +1063,663 @@ test('Stale overrideOptions do not bleed into subsequent navigations', async (as
   to('/rz')
   await navigate.call(host)
   assert.equal(destroyCount, 1, '/ry should be destroyed — stale keepAlive must not persist')
+
+  stage.element = originalElement
+})
+
+test('afterEach and after hooks fire in order with correct args and this context', async (assert) => {
+  const originalElement = stage.element
+  stage.element = ({ parent }) => ({
+    populate() {},
+    set(prop, value) {
+      if (value && value.transition && typeof value.transition.end === 'function') {
+        value.transition.end()
+      }
+    },
+    destroy() {},
+    parent,
+  })
+
+  const TestComponent = Component('TestComponent', {
+    template: '<Element />',
+    code: { render: () => ({ elms: [], cleanup: () => {} }), effects: [] },
+  })
+
+  const callLog = []
+  const parentRef = {
+    [symbols.routes]: [
+      {
+        path: '/ahook-from',
+        component: TestComponent,
+        options: { inHistory: true, passFocus: false },
+      },
+      {
+        path: '/ahook-to',
+        component: TestComponent,
+        options: { inHistory: true, passFocus: false },
+        hooks: {
+          after(toRoute, fromRoute) {
+            callLog.push({
+              hook: 'after',
+              to: toRoute.path,
+              from: fromRoute && fromRoute.path,
+              self: this,
+            })
+          },
+        },
+      },
+    ],
+    [symbols.routerHooks]: {
+      afterEach(toRoute, fromRoute) {
+        callLog.push({
+          hook: 'afterEach',
+          to: toRoute.path,
+          from: fromRoute && fromRoute.path,
+          self: this,
+        })
+      },
+    },
+  }
+
+  const host = { [symbols.parent]: parentRef, [symbols.children]: [{}], [symbols.props]: {} }
+
+  to('/ahook-from')
+  await navigate.call(host)
+  to('/ahook-to')
+  await navigate.call(host)
+
+  const relevant = callLog.filter((e) => e.to === '/ahook-to')
+  assert.deepEqual(
+    relevant.map((e) => e.hook),
+    ['afterEach', 'after'],
+    'Hooks should fire in correct order'
+  )
+  assert.equal(relevant[0].from, '/ahook-from', 'afterEach should receive previous route as from')
+  assert.equal(relevant[1].from, '/ahook-from', 'after should receive previous route as from')
+  assert.equal(relevant[0].self, parentRef, 'afterEach this context should be the parent component')
+  assert.equal(relevant[1].self, parentRef, 'after this context should be the parent component')
+  assert.equal(state.navigating, false, 'state.navigating should reset after hooks complete')
+
+  stage.element = originalElement
+})
+
+test('afterEach and after errors do not break navigation', async (assert) => {
+  const originalElement = stage.element
+  stage.element = ({ parent }) => ({
+    populate() {},
+    set(prop, value) {
+      if (value && value.transition && typeof value.transition.end === 'function') {
+        value.transition.end()
+      }
+    },
+    destroy() {},
+    parent,
+  })
+
+  const TestComponent = Component('TestComponent', {
+    template: '<Element />',
+    code: { render: () => ({ elms: [], cleanup: () => {} }), effects: [] },
+  })
+
+  let afterCalled = false
+
+  const host = {
+    [symbols.parent]: {
+      [symbols.routes]: [
+        {
+          path: '/err-from',
+          component: TestComponent,
+          options: { inHistory: true, passFocus: false },
+        },
+        {
+          path: '/err-to',
+          component: TestComponent,
+          options: { inHistory: true, passFocus: false },
+          hooks: {
+            after() {
+              afterCalled = true
+              throw new Error('per-route after boom')
+            },
+          },
+        },
+      ],
+      [symbols.routerHooks]: {
+        afterEach() {
+          throw new Error('afterEach boom')
+        },
+      },
+    },
+    [symbols.children]: [{}],
+    [symbols.props]: {},
+  }
+
+  to('/err-from')
+  await navigate.call(host)
+  to('/err-to')
+  await navigate.call(host)
+
+  assert.ok(afterCalled, 'Per-route after should still run despite afterEach error')
+  assert.equal(state.navigating, false, 'state.navigating should reset despite both hooks throwing')
+  assert.equal(state.path, '/err-to', 'Navigation should complete despite both hooks throwing')
+
+  stage.element = originalElement
+})
+
+test('after hooks do not fire when beforeEach cancels navigation', async (assert) => {
+  const originalElement = stage.element
+  stage.element = ({ parent }) => ({
+    populate() {},
+    set(prop, value) {
+      if (value && value.transition && typeof value.transition.end === 'function') {
+        value.transition.end()
+      }
+    },
+    destroy() {},
+    parent,
+  })
+
+  const TestComponent = Component('TestComponent', {
+    template: '<Element />',
+    code: { render: () => ({ elms: [], cleanup: () => {} }), effects: [] },
+  })
+
+  const seedHost = {
+    [symbols.parent]: {
+      [symbols.routes]: [
+        {
+          path: '/hist-seed-a',
+          component: TestComponent,
+          options: { inHistory: true, passFocus: false },
+        },
+        {
+          path: '/hist-seed-b',
+          component: TestComponent,
+          options: { inHistory: true, passFocus: false },
+        },
+      ],
+    },
+    [symbols.children]: [{}],
+    [symbols.props]: {},
+  }
+  to('/hist-seed-a')
+  await navigate.call(seedHost)
+  to('/hist-seed-b')
+  await navigate.call(seedHost)
+
+  let afterEachCalled = false
+  let afterCalled = false
+
+  const host = {
+    [symbols.parent]: {
+      [symbols.routes]: [
+        {
+          path: '/cancel-from',
+          component: TestComponent,
+          options: { inHistory: true, passFocus: false },
+        },
+        {
+          path: '/cancel-to',
+          component: TestComponent,
+          options: { inHistory: true, passFocus: false },
+          hooks: {
+            after() {
+              afterCalled = true
+            },
+          },
+        },
+      ],
+      [symbols.routerHooks]: {
+        beforeEach() {
+          return false
+        },
+        afterEach() {
+          afterEachCalled = true
+        },
+      },
+    },
+    [symbols.children]: [{}],
+    [symbols.props]: {},
+  }
+
+  to('/cancel-from')
+  await navigate.call(host)
+  to('/cancel-to')
+  await navigate.call(host)
+
+  assert.equal(afterEachCalled, false, 'afterEach should not fire when beforeEach cancels')
+  assert.equal(afterCalled, false, 'after should not fire when beforeEach cancels')
+  assert.equal(state.navigating, false, 'state.navigating should reset after cancelled navigations')
+
+  stage.element = originalElement
+})
+
+test('after hook receives correct route data and params', async (assert) => {
+  const originalElement = stage.element
+  stage.element = ({ parent }) => ({
+    populate() {},
+    set(prop, value) {
+      if (value && value.transition && typeof value.transition.end === 'function') {
+        value.transition.end()
+      }
+    },
+    destroy() {},
+    parent,
+  })
+
+  const TestComponent = Component('TestComponent', {
+    template: '<Element />',
+    code: { render: () => ({ elms: [], cleanup: () => {} }), effects: [] },
+  })
+
+  /** @type {import('./router.js').Route | null} */
+  let capturedTo = null
+
+  const host = {
+    [symbols.parent]: {
+      [symbols.routes]: [
+        {
+          path: '/data-from',
+          component: TestComponent,
+          options: { inHistory: true, passFocus: false },
+        },
+        {
+          path: '/data-to/:id',
+          component: TestComponent,
+          options: { inHistory: true, passFocus: false },
+          data: { title: 'Detail' },
+          hooks: {
+            after(toRoute) {
+              capturedTo = toRoute
+            },
+          },
+        },
+      ],
+    },
+    [symbols.children]: [{}],
+    [symbols.props]: {},
+  }
+
+  to('/data-from')
+  await navigate.call(host)
+  to('/data-to/42', { extra: 'info' })
+  await navigate.call(host)
+
+  assert.ok(capturedTo, 'after hook should have been called')
+  assert.equal(capturedTo?.path, '/data-to/:id', 'toRoute should have the route definition path')
+  assert.deepEqual(capturedTo?.params, { id: '42' }, 'toRoute should have extracted params')
+  assert.equal(capturedTo?.data?.title, 'Detail', 'toRoute.data should contain static route data')
+  assert.equal(capturedTo?.data?.extra, 'info', 'toRoute.data should contain navigation data')
+
+  stage.element = originalElement
+})
+
+test('beforeEach rejection still clears navigating state when history is non-empty', async (assert) => {
+  const originalElement = stage.element
+  stage.element = ({ parent }) => ({
+    populate() {},
+    set(prop, value) {
+      if (value && value.transition && typeof value.transition.end === 'function') {
+        value.transition.end()
+      }
+    },
+    destroy() {},
+    parent,
+  })
+
+  const SeedCmp = Component('ThrowSeedCmp', {
+    template: '<Element />',
+    code: { render: () => ({ elms: [], cleanup: () => {} }), effects: [] },
+  })
+  const FailCmp = Component('HookFailTarget', {
+    template: '<Element />',
+    code: { render: () => ({ elms: [], cleanup: () => {} }), effects: [] },
+  })
+
+  const seedHost = {
+    [symbols.parent]: {
+      [symbols.routes]: [
+        {
+          path: '/throw-seed-a',
+          component: SeedCmp,
+          options: { inHistory: true, passFocus: false },
+        },
+        {
+          path: '/throw-seed-b',
+          component: SeedCmp,
+          options: { inHistory: true, passFocus: false },
+        },
+      ],
+    },
+    [symbols.children]: [{}],
+    [symbols.props]: {},
+  }
+  to('/throw-seed-a')
+  await navigate.call(seedHost)
+  to('/throw-seed-b')
+  await navigate.call(seedHost)
+
+  const host = {
+    [symbols.parent]: {
+      [symbols.routes]: [
+        {
+          path: '/hook-fail-target',
+          component: FailCmp,
+          options: { inHistory: true, passFocus: false },
+        },
+      ],
+      [symbols.routerHooks]: {
+        async beforeEach() {
+          throw new Error('BeforeEach hook failed')
+        },
+      },
+    },
+    [symbols.children]: [{}],
+    [symbols.props]: {},
+  }
+
+  to('/hook-fail-target')
+  await navigate.call(host)
+
+  assert.equal(state.navigating, false, 'Navigation state should reset after hook failure')
+
+  stage.element = originalElement
+})
+
+test('beforeEach returning false leaves state.path on previous route', async (assert) => {
+  const originalElement = stage.element
+  stage.element = ({ parent }) => ({
+    populate() {},
+    set(prop, value) {
+      if (value && value.transition && typeof value.transition.end === 'function') {
+        value.transition.end()
+      }
+    },
+    destroy() {},
+    parent,
+  })
+
+  const SeedCmp = Component('EachSeedCmp', {
+    template: '<Element />',
+    code: { render: () => ({ elms: [], cleanup: () => {} }), effects: [] },
+  })
+  const GuardCmp = Component('GuardFalseEach', {
+    template: '<Element />',
+    code: { render: () => ({ elms: [], cleanup: () => {} }), effects: [] },
+  })
+
+  const seedHost = {
+    [symbols.parent]: {
+      [symbols.routes]: [
+        {
+          path: '/each-seed-a',
+          component: SeedCmp,
+          options: { inHistory: true, passFocus: false },
+        },
+        {
+          path: '/each-seed-b',
+          component: SeedCmp,
+          options: { inHistory: true, passFocus: false },
+        },
+      ],
+    },
+    [symbols.children]: [{}],
+    [symbols.props]: {},
+  }
+  to('/each-seed-a')
+  await navigate.call(seedHost)
+  to('/each-seed-b')
+  await navigate.call(seedHost)
+
+  const host = {
+    [symbols.parent]: {
+      [symbols.routes]: [
+        {
+          path: '/guard-each-1',
+          component: GuardCmp,
+          options: { inHistory: true, passFocus: false },
+        },
+        {
+          path: '/guard-each-2',
+          component: GuardCmp,
+          options: { inHistory: true, passFocus: false },
+        },
+      ],
+      [symbols.routerHooks]: {
+        beforeEach(toRoute) {
+          if (toRoute.path === '/guard-each-2') {
+            return false
+          }
+        },
+      },
+    },
+    [symbols.children]: [{}],
+    [symbols.props]: {},
+  }
+
+  to('/guard-each-1')
+  await navigate.call(host)
+  to('/guard-each-2')
+  await navigate.call(host)
+
+  assert.equal(
+    state.path,
+    '/guard-each-1',
+    'Navigation should be cancelled when beforeEach returns false'
+  )
+
+  stage.element = originalElement
+})
+
+test('route before returning false leaves state.path on previous route', async (assert) => {
+  const originalElement = stage.element
+  stage.element = ({ parent }) => ({
+    populate() {},
+    set(prop, value) {
+      if (value && value.transition && typeof value.transition.end === 'function') {
+        value.transition.end()
+      }
+    },
+    destroy() {},
+    parent,
+  })
+
+  const SeedCmp = Component('BeforeSeedCmp', {
+    template: '<Element />',
+    code: { render: () => ({ elms: [], cleanup: () => {} }), effects: [] },
+  })
+  const GuardCmp = Component('GuardFalseBefore', {
+    template: '<Element />',
+    code: { render: () => ({ elms: [], cleanup: () => {} }), effects: [] },
+  })
+
+  const seedHost = {
+    [symbols.parent]: {
+      [symbols.routes]: [
+        {
+          path: '/before-seed-a',
+          component: SeedCmp,
+          options: { inHistory: true, passFocus: false },
+        },
+        {
+          path: '/before-seed-b',
+          component: SeedCmp,
+          options: { inHistory: true, passFocus: false },
+        },
+      ],
+    },
+    [symbols.children]: [{}],
+    [symbols.props]: {},
+  }
+  to('/before-seed-a')
+  await navigate.call(seedHost)
+  to('/before-seed-b')
+  await navigate.call(seedHost)
+
+  const host = {
+    [symbols.parent]: {
+      [symbols.routes]: [
+        {
+          path: '/guard-before-1',
+          component: GuardCmp,
+          options: { inHistory: true, passFocus: false },
+        },
+        {
+          path: '/guard-before-2',
+          component: GuardCmp,
+          options: { inHistory: true, passFocus: false },
+          hooks: {
+            before() {
+              return false
+            },
+          },
+        },
+      ],
+    },
+    [symbols.children]: [{}],
+    [symbols.props]: {},
+  }
+
+  to('/guard-before-1')
+  await navigate.call(host)
+  to('/guard-before-2')
+  await navigate.call(host)
+
+  assert.equal(
+    state.path,
+    '/guard-before-1',
+    'Navigation should be cancelled when route before returns false'
+  )
+
+  stage.element = originalElement
+})
+
+test('keepAlive caches view and restores same instance on back', async (assert) => {
+  const originalElement = stage.element
+  let initCallCount = 0
+
+  stage.element = ({ parent }) => ({
+    populate() {},
+    set(prop, value) {
+      if (value && value.transition && typeof value.transition.end === 'function') {
+        value.transition.end()
+      }
+    },
+    destroy() {},
+    parent,
+  })
+
+  const KaOne = Component('KaRestoreOne', {
+    template: '<Element />',
+    code: {
+      render: () => ({ elms: [], cleanup: () => {} }),
+      effects: [],
+      init() {
+        initCallCount++
+      },
+    },
+  })
+  const KaTwo = Component('KaRestoreTwo', {
+    template: '<Element />',
+    code: { render: () => ({ elms: [], cleanup: () => {} }), effects: [] },
+  })
+
+  const host = {
+    [symbols.parent]: {
+      [symbols.routes]: [
+        {
+          path: '/ka-restore-1',
+          component: KaOne,
+          options: { keepAlive: true, inHistory: true, passFocus: false },
+        },
+        {
+          path: '/ka-restore-2',
+          component: KaTwo,
+          options: { inHistory: true, passFocus: false },
+        },
+      ],
+    },
+    [symbols.children]: [{}],
+    [symbols.props]: {},
+  }
+
+  const kaChildren = /** @type {any[]} */ (/** @type {unknown} */ (host[symbols.children]))
+
+  to('/ka-restore-1')
+  await navigate.call(host)
+  const page1View = kaChildren[kaChildren.length - 1]
+  const initialInitCount = initCallCount
+
+  to('/ka-restore-2')
+  await navigate.call(host)
+
+  assert.equal(back.call(host), true, 'back() should pop history and queue previous route')
+  await navigate.call(host)
+
+  const restoredView = kaChildren[kaChildren.length - 1]
+  assert.equal(restoredView, page1View, 'Should restore the same cached view instance')
+  assert.equal(
+    initCallCount,
+    initialInitCount,
+    'Component init should not run again when restored from cache'
+  )
+
+  stage.element = originalElement
+})
+
+test('reuseComponent reuses the same view instance when returning to the route', async (assert) => {
+  const originalElement = stage.element
+
+  stage.element = ({ parent }) => ({
+    populate() {},
+    set(prop, value) {
+      if (value && value.transition && typeof value.transition.end === 'function') {
+        value.transition.end()
+      }
+    },
+    destroy() {},
+    parent,
+  })
+
+  const SharedRc = Component('RcReuseShared', {
+    template: '<Element />',
+    code: { render: () => ({ elms: [], cleanup: () => {} }), effects: [] },
+  })
+
+  const host = {
+    [symbols.parent]: {
+      [symbols.routes]: [
+        {
+          path: '/rc-reuse-1',
+          component: SharedRc,
+          options: { reuseComponent: true, keepAlive: false, inHistory: true, passFocus: false },
+        },
+        {
+          path: '/rc-reuse-2',
+          component: SharedRc,
+          options: { reuseComponent: true, inHistory: true, passFocus: false },
+        },
+      ],
+    },
+    [symbols.children]: [{}],
+    [symbols.props]: {},
+  }
+
+  to('/rc-reuse-1')
+  await navigate.call(host)
+  const firstView = host.activeView
+
+  to('/rc-reuse-2')
+  await navigate.call(host)
+
+  to('/rc-reuse-1')
+  await navigate.call(host)
+  const secondView = host.activeView
+
+  assert.equal(
+    firstView,
+    secondView,
+    'Should reuse the same component instance when reuseComponent is true'
+  )
 
   stage.element = originalElement
 })


### PR DESCRIPTION
- Fixed left over `KeyboardEvent.code` references
- Fixed issue with allowing $-prefix to be used as text content
- Fixed issue with internal keyboard event not working on older browsers
- Added tests to router hooks
- Fixed issue with transitions not being skipped when duration is set to `0`
- Added `this.$nextTick` utility helper
- Fixed issue with transitioning colours in `border`-attribute
