### PR TITLE
Fixes broken links in docs

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -30,7 +30,7 @@
   - [Hooks](/router/hooks.md)
   - [Transitions](/router/transitions.md)
 - Shaders
-  - [Importing Shaders](/shaders/importing-shader.md)
+  - [Importing Shaders](/shaders/importing-shaders.md)
   - [WebGl Shaders](/shaders/webgl-shadertypes.md)
   - [Canvas Shaders](/shaders/canvas-shadertypes.md)
   - [v2 Conversion Guide](/shaders/v2-conversion-guide.md)
@@ -41,4 +41,4 @@
   - [Global App State](/plugins/global_app_state.md)
   - [Storage](/plugins/storage.md)
 - Performance
-  - [Lazy loading]('/performance/lazy-loading.md')
+  - [Lazy loading](/performance/lazy-loading.md)

--- a/docs/built-in/for-loop.md
+++ b/docs/built-in/for-loop.md
@@ -1,6 +1,6 @@
 # For loop
 
-The for loop is technically also a [directive](../directives.md), but such an important one that it deserves its own section.
+The for loop is technically also a [directive](./directives.md), but such an important one that it deserves its own section.
 
 The for loop directive can be used when you want to repeat multiple instances of an Element or a Component, without having to specify them hardcoded one by one in your template.
 

--- a/docs/performance/lazy-loading.md
+++ b/docs/performance/lazy-loading.md
@@ -1,6 +1,6 @@
 # Lazy Loading with the :range Parameter
 
-The for-loop in Blits comes with a [`:range` parameter](../built-in/for-loop.html#using-the-range-attribute) that allows you to render only a portion of an array rather than all the items.
+The for-loop in Blits comes with a [`:range` parameter](../built-in/for-loop.md#using-the-range-attribute) that allows you to render only a portion of an array rather than all the items.
 
 This `:range` parameter can also be used to easily implement an efficient form of _lazy loading_. Lazy loading is a crucial concept for performance in TV applications where rails can contain hundreds of items, but only a small subset is visible at any time.
 

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -142,15 +142,15 @@
       },
       {
         "text": "WebGl Shaders",
-        "link": "/built-in/webgl-shadertypes"
+        "link": "/shaders/webgl-shadertypes"
       },
       {
-        "text": "Canvase Shaders",
-        "link": "/built-in/webgl-shadertypes"
+        "text": "Canvas Shaders",
+        "link": "/shaders/canvas-shadertypes"
       },
       {
         "text": "v2 Conversion Guide",
-        "link": "/built-in/v2-conversion-guide"
+        "link": "/shaders/v2-conversion-guide"
       }
     ]
   },


### PR DESCRIPTION

It fixes a few broken links in the docs navigation, including the incorrect links in the `Shader` section of the table of contents.