### PR TITLE
Fix documentation issues

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -9,6 +9,7 @@
   - [Supported element attributes](/essentials/element_attributes.md)
   - [Displaying images](/essentials/displaying_images.md)
   - [Displaying text](/essentials/displaying_text.md)
+  - [Application settings](/essentials/settings.md)
 - Components
   - [State](/components/component_state.md)
   - [Props](/components/props.md)

--- a/docs/components/component_state.md
+++ b/docs/components/component_state.md
@@ -53,7 +53,7 @@ The example below gives a full example of defining and using a component's state
 export default Blits.Component('MyComponent', {
   template: `
     <Element :show="$active">
-      <Element :x="$style.x" w="100" :h="$style.dimensions.h">
+      <Element :x="$style.positions.x" w="100" :h="$style.dimensions.h">
         <Element w="20" :h="$style.dimensions.h / 2" :color="$color" />
       </Element>
     </Element>
@@ -72,7 +72,7 @@ export default Blits.Component('MyComponent', {
       },
       color: 'tomato'
     }
-  }
+  },
   hooks: {
     ready() {
       this.active = true

--- a/docs/components/mouse_support.md
+++ b/docs/components/mouse_support.md
@@ -39,7 +39,7 @@ Hover applies only to **components**, not to individual `Element` nodes. A compo
 export default Blits.Component('Card', {
   template: `
     <Element
-      :color="$$isHovered ? 0x4488ff : 0x222222"
+      :color="$$isHovered ? '#4488ff' : '#222222'"
     />
   `,
   state() {

--- a/docs/components/props.md
+++ b/docs/components/props.md
@@ -45,7 +45,7 @@ Types are inferred based on the default value of a prop. Types can also be added
 
 ```js
 props: {
-  bgColor: 'red' // type string is inferred
+  bgColor: 'red', // type string is inferred
   /**
    * Height of the element
    * @type {number|undefined}

--- a/docs/components/user_input.md
+++ b/docs/components/user_input.md
@@ -59,26 +59,28 @@ If the currently focused component does not handle a key press, Blits will trave
 
 When a component handles a key press by having a corresponding function specified, said component receives focus, and the event handling chain stops by default. However, if you want the input event to propagate up the hierarchy further, you have three options:
 
-1. **Change focus only (no bubbling)**: Use `this.parent.$focus()` without the event parameter. This only changes focus to the parent and does not bubble the event.
-2. **Change focus and bubble the event**: Use `this.parent.$focus(e)` with the event parameter. This changes focus to the parent AND bubbles the event to the parent's input handler.
-3. **Handle input without changing focus**: Use `this.parent.$input(e)`. This handles the input event on the parent WITHOUT changing focus. You can also use `this.$select('ref').$input(e)` to handle input on any component selected by ref.
+1. **Change focus only (no bubbling)**: Use `this.$parent.$focus()` without the event parameter. This only changes focus to the parent and does not bubble the event.
+2. **Change focus and bubble the event**: Use `this.$parent.$focus(e)` with the event parameter. This changes focus to the parent AND bubbles the event to the parent's input handler.
+3. **Handle input without changing focus**: Use `this.$parent.$input(e)`. This handles the input event on the parent WITHOUT changing focus. You can also use `this.$select('ref').$input(e)` to handle input on any component selected by ref.
 
-**Note**: Both `this.parent.$focus(e)` and `this.parent.$input(e)` process events on the parent. The difference is that `$focus()` changes focus, while `$input()` only handles the input event.
+**Note**: Both `this.$parent.$focus(e)` and `this.$parent.$input(e)` process events on the parent. The difference is that `$focus()` changes focus, while `$input()` only handles the input event.
+
+> **v2**: `this.parent` was renamed to `this.$parent` in Blits v2.
 
 ```javascript
 {
   input: {
     enter() {
       // Give focus to the parent (without bubbling the event)
-      this.parent.$focus();
+      this.$parent.$focus();
     },
     back(e) {
       // Give focus to the parent and let the user input event bubble
-      this.parent.$focus(e);
+      this.$parent.$focus(e);
     },
     escape(e) {
       // Handle input on parent but keep focus on current component
-      this.parent.$input(e);
+      this.$parent.$input(e);
     },
   }
 }
@@ -138,7 +140,7 @@ Blits.Component('MyComponent', {
       this.leftHold = false
     }
   }
-}
+})
 ```
 
 ## Custom Keycode mapping

--- a/docs/components/utility_methods.md
+++ b/docs/components/utility_methods.md
@@ -62,7 +62,9 @@ export default Blits.Component('MyComponent', {
     </Element>
   `,
   state() {
-    focusIndex: 1
+    return {
+      focusIndex: 1
+    }
   },
   input: {
     down() {
@@ -108,11 +110,13 @@ When the `$focus` method is called on a Component that is already is a focused s
 The `$input()`-method handles keyboard events on a component **without changing focus**. It works similarly to `$focus()`, but for input handling instead of focus management.
 
 **Comparison with `$focus()` methods:**
-- `this.parent.$focus()` - Changes focus to parent **ONLY** (no event parameter = no bubbling)
-- `this.parent.$focus(e)` - Changes focus to parent **AND** bubbles the event (with event parameter)
-- `this.parent.$input(e)` - Handles the input event on parent **ONLY** (no focus change)
+- `this.$parent.$focus()` - Changes focus to parent **ONLY** (no event parameter = no bubbling)
+- `this.$parent.$focus(e)` - Changes focus to parent **AND** bubbles the event (with event parameter)
+- `this.$parent.$input(e)` - Handles the input event on parent **ONLY** (no focus change)
 
-Both `this.parent.$focus(e)` and `this.parent.$input(e)` process events on the parent. The difference is that `$focus()` changes focus, while `$input()` only handles the input event.
+Both `this.$parent.$focus(e)` and `this.$parent.$input(e)` process events on the parent. The difference is that `$focus()` changes focus, while `$input()` only handles the input event.
+
+> **v2**: `this.parent` was renamed to `this.$parent` in Blits v2.
 
 **When to use `$input`:**
 Use this when you need another component (like a parent) to handle the key but want to keep focus on the current component.
@@ -127,13 +131,13 @@ export default Blits.Component('MyComponent', {
     enter(e) {
       // Handle the enter key locally
       this.doSomething()
-      
+
       // Also let parent handle it without changing focus
-      this.parent.$input(e)
+      this.$parent.$input(e)
     },
     back(e) {
       // Let parent handle back key, but keep focus here
-      if (this.parent.$input(e)) {
+      if (this.$parent.$input(e)) {
         // Parent handled it
         return
       }
@@ -151,7 +155,7 @@ export default Blits.Component('MyComponent', {
 })
 ```
 
-> **Note**: The `$input()` method works on the component it's called on (like `$focus()`), so call it on the target component (e.g., `this.parent.$input(e)` or `this.$select('ref').$input(e)`) to handle input on that component without changing focus.
+> **Note**: The `$input()` method works on the component it's called on (like `$focus()`), so call it on the target component (e.g., `this.$parent.$input(e)` or `this.$select('ref').$input(e)`) to handle input on that component without changing focus.
 
 ### $trigger
 
@@ -162,9 +166,11 @@ Instead of setting a value to `null` and then setting it back to the initial val
 ```js
 export default Blits.Component('MyComponent', {
   state() {
-    focusIndex: 1
+    return {
+      focusIndex: 1
+    }
   },
-  watchers: {
+  watch: {
     focusIndex(v) {
       console.log('I trigger when focusIndex changes')
     }
@@ -222,7 +228,7 @@ Note that this recursive operation comes at a cost, especially when emitting lar
 
 
 ```js
-// explicitely _not_ passing this.navigationResult by reference
+// explicitly _not_ passing this.navigationResult by reference
 this.$emit('setMenuItems', this.navigationResult, false)
 ```
 
@@ -347,7 +353,9 @@ The `this.$clearTimeouts()`-method is a utility method that is used to clear all
 ```js
 export default Blits.Component('MyComponent', {
   state() {
-    timeout: null
+    return {
+      timeout: null
+    }
   },
   hooks: {
     init() {

--- a/docs/components/watchers.md
+++ b/docs/components/watchers.md
@@ -50,7 +50,7 @@ You can also define watchers for nested component states using dot notation to s
     }
   },
   watch: {
-    'size.h'(h: number) {
+    'size.h'(h) {
       // Execute some logic when the 'size.h' value changes
     },
   }

--- a/docs/essentials/displaying_images.md
+++ b/docs/essentials/displaying_images.md
@@ -15,7 +15,7 @@ Remote images are also supported and can be linked directly (e.g., `http://mycdn
 
 ## Sizing and Scaling
 
-Make sure to give your Element a width (`w` ) and a height (`h`) attribute. Images will _not_ be rendered if they don't have both attributes present. The Lightning renderer will scale the image to fit these exact dimensions.
+It is recommended to give your Element a width (`w`) and a height (`h`) attribute so the Lightning renderer can scale the image to those exact dimensions. If neither is specified, the image will render at its natural dimensions. For best control over layout, always set explicit dimensions.
 
 For the best performance, it's important to keep your source images as small as possible. If you're displaying an image at `200px x 200px`, make sure the image is exactly that size or _smaller_. The latter option may lead to some quality loss, but can positively impact the overall performance of your App.
 

--- a/docs/essentials/displaying_text.md
+++ b/docs/essentials/displaying_text.md
@@ -25,7 +25,7 @@ The Text-tag accepts the following attributes:
 - `color` - the color to display for the text, defaults to `white` and can be any of the supported Blits color formats (HTML, hexadecimal or rgb(a))
 - `letterspacing` - letterspacing in pixels, defaults to `0`
 - `align` - the alignment of the text, can be `left`, `right`, or `center`, defaults to `left`. Centering text and aligning text to the right requires the `maxwidth` attribute to be set as well.
-- `maxwidth` - the max length of a line of text in pixels, words surpassing this length will be broken and wrapped onto the next line. This attribute is required when aligning center or right. Previously this attribute was `wordwrap`, which has now been deprecated in favour of `maxwidth`.
+- `maxwidth` - the max length of a line of text in pixels, words surpassing this length will be broken and wrapped onto the next line. This attribute is required when aligning center or right. Previously this attribute was `wordwrap`, which has been fully removed in Blits v2 (in v1, `wordwrap` still works).
 - `maxlines` - maximum number of lines that will be displayed
 - `maxheight` - maximum height of a text block, lines that don't fit within this height will not be displayed
 - `lineheight` - the spacing between lines in pixels
@@ -65,6 +65,7 @@ export default Blits.Component('MyComponent', {
       this.y = dimensions.h + 8
     }
   }
+})
 ```
 
 ## Text overflow

--- a/docs/essentials/element_attributes.md
+++ b/docs/essentials/element_attributes.md
@@ -11,8 +11,10 @@ In order to position and set the dimensions of an Element, the following attribu
   - `x` - the x position of the Element in pixels, relative to its parent - allows negative values and decimals
   - `y` - the y position of the Element in pixels, relative to its parent - allows negative values and decimals
   - `z` - the z index of the element (optionally `zIndex` can be used as an alias)
-  - `w` - the width of the element in pixels (optionally `width` can be used as an alias)
-  - `h` - the height of the element in pixels (optionally `height` can be used as an alias)
+  - `w` - the width of the element in pixels
+  - `h` - the height of the element in pixels
+
+> **Note (v1 only):** In Blits v1, `width` and `height` could be used as aliases for `w` and `h`. These aliases were removed in Blits v2. Use `w` and `h` directly.
 
 All positioning and dimension related attributes, when not specified, will default to `0`.
 
@@ -107,7 +109,7 @@ Again, you can use "normal" notation for the colors (like hexadecimal or rgba) a
 ```xml
 <Element w="200" h="200" color="{top: 'red', bottom: 'blue'}" />
 <Element w="200" h="200" color="{left: 'rgba(255,255,255,.5)', right: '#000'}" />
-<Element w="200" h="200" color="{left: '#aaa333', top: 'aqua', 'bottom: rgb(255,100,20)'}" />
+<Element w="200" h="200" color="{left: '#aaa333', top: 'aqua', bottom: 'rgb(255,100,20)'}" />
 <Element w="200" h="200" color="{bottom: 'black'}" />
 ```
 
@@ -192,7 +194,7 @@ By default contents inside an Element (i.e. child Elements) will overflow the bo
 
 In order to contain / cut off the content inside an Element's `w` and `h`, you can add the `clipping="true"`-attribute. Setting `clipping` to `false` restores the default behaviour of content overflowing.
 
-Alternatively you can also use the `overflow`-attribute (and pass it `true` or `false`), which works similar to clipping just mapped inversly (i.e. `overflow="false"` ensures content that surpasses the parent dimensions is clipped-off).
+Alternatively you can also use the `overflow`-attribute (and pass it `true` or `false`), which works similar to clipping just mapped inversely (i.e. `overflow="false"` ensures content that surpasses the parent dimensions is clipped-off).
 
 ## Shaders
 
@@ -201,7 +203,7 @@ Generally Elements that have a color or texture are simply rendered as a rectang
 In Blits there are two ways to apply these Shaders.
 
 ### Built-in Element Shader attributes
-For better a better development experience Blits had the following shader attributes regularly used in app development:
+For a better development experience Blits had the following shader attributes regularly used in app development:
 
 - `rounded` - Allows you to round corners of an Element. You can do this with a single value, array, or object. ([details](https://lightningjs.io/api/renderer/interfaces/Renderer.RoundedProps.html))
 - `border` - Allows you to add an inner border to an Element. You can do this with an object. ([details](https://lightningjs.io/api/renderer/interfaces/Renderer.BorderProps.html))

--- a/docs/essentials/settings.md
+++ b/docs/essentials/settings.md
@@ -76,7 +76,7 @@ Example font object:
 
 | Setting         | Type      | Description |
 |----------------|-----------|-------------|
-| `effects`      | `ShaderEffect[]` | Effects for DynamicShader |
+| ~~`effects`~~  | `ShaderEffect[]` | Effects for DynamicShader. **Removed in Blits v2.** Use the `shaders` setting instead. |
 | `shaders`      | `Shader[]` | Custom shaders |
 
 ## Inspector & Debugging

--- a/docs/essentials/template_syntax.md
+++ b/docs/essentials/template_syntax.md
@@ -50,7 +50,7 @@ Reactive arguments also support _interpolation_. This enables the use of simple 
 
 For more complex logic, it's recommended to abstract this into a [Component method](../components/methods.md) or a [Computed property](../components/computed_properties.md).
 
-# Abstracting template portions to custom components
+## Abstracting template portions to custom components
 
 As your template grows in complexity, you may want to organize your codebase with custom components, abstracting a complex template into smaller, reusable pieces.
 

--- a/docs/performance/lazy-loading.md
+++ b/docs/performance/lazy-loading.md
@@ -38,11 +38,11 @@ export default Blits.Component('RangedRail', {
   },
   input: {
     right() {
-      this.focus = Math.min(this.focus + 1, items.length)
+      this.focused = Math.min(this.focused + 1, this.items.length)
       this.range++
     },
     left() {
-      this.focus = Math.max(this.focus - 1, 0)
+      this.focused = Math.max(this.focused - 1, 0)
       this.range--
     }
   }
@@ -90,14 +90,14 @@ export default Blits.Component('LazyRail', {
   },
   input: {
     right() {
-      this.focus = Math.min(this.focus + 1, items.length)
+      this.focused = Math.min(this.focused + 1, this.items.length)
       // push the range update to the next tick to spread out the work
       // and ease the CPU a bit
-      this.$setTimeout(() => this.range = this.focus)
+      this.$setTimeout(() => this.range = this.focused)
 
     },
     left() {
-      this.focus = Math.max(this.focus - 1, 0)
+      this.focused = Math.max(this.focused - 1, 0)
       // we don't decrement the range when scrolling back to keep components alive
       // this.range--
     }

--- a/docs/plugins/language.md
+++ b/docs/plugins/language.md
@@ -148,7 +148,7 @@ Blits.Component('MyComponent', {
   template: `
     <Element>
       <Text :content="$$language.translate('hello')" />
-      <Text y="100" :content="$$language.get()" />
+      <Text y="100" :content="$$language.translate('world')" />
     </Element>
   `,
   hooks: {
@@ -167,7 +167,7 @@ The second `$`-sign is needed, since the Language plugin itself is prefixed with
 
 ### Dynamic replacements
 
-The `tranlate()`-method also supports dynamic replacements. This allows you to specify variables inside your translation string, and replace them with dynamic values passed into the `translate()`-method.
+The `translate()`-method also supports dynamic replacements. This allows you to specify variables inside your translation string, and replace them with dynamic values passed into the `translate()`-method.
 
 Replacements are marked in the translation value using _handlebars_, like so:
 

--- a/docs/plugins/storage.md
+++ b/docs/plugins/storage.md
@@ -32,7 +32,7 @@ Blits.Launch(App, 'app', {
 Within the application we can call the storage plugin methods as below
 
 ```
-this.$storage.get(key, value)
+this.$storage.get(key)
 ```
 
 ## TypeScript Support

--- a/docs/plugins/text-to-speech-announcer.md
+++ b/docs/plugins/text-to-speech-announcer.md
@@ -35,7 +35,7 @@ Blits.Component('MyComponent', {
       this.$announcer.speak('MyComponent just got focus')
     }
   },
-  keys: {
+  input: {
     right() {
       if(this.focused === this.items.length - 1) {
         this.$announcer.speak('End of row reached')
@@ -124,7 +124,7 @@ Blits.Application({
 })
 ```
 
-#### Clearing and interupting
+#### Clearing and interrupting
 
 Since each message added into the queue may take a bit of time to actually be announced, it's possible that the user has navigated elsewhere in the mean time, making the queued up messages not relevant.
 
@@ -170,8 +170,8 @@ By default the announcer is disabled. This means that whenever you call `this.$a
 
 In order to enable utterances being spoken out, you can set the Blits launch setting `announcer` to `true` in the index.js.
 
-Alternatively the announcer can be enabled or disabled run time by using one of the following methods on the Announcer pluging:
+Alternatively the announcer can be enabled or disabled run time by using one of the following methods on the Announcer plugin:
 
 - `this.$announcer.enable()` - activates the announcer
 - `this.$announcer.disable()` - deactivates the announcer
-- `this.$announcer.disable(true/false)` - turns the announcer on or off
+- `this.$announcer.toggle(true/false)` - turns the announcer on or off

--- a/docs/plugins/theme.md
+++ b/docs/plugins/theme.md
@@ -190,7 +190,7 @@ Blits.Component('MyComponent', {
       this.$theme.current('dark')
     },
     down() {
-      this.$theme.current('default')
+      this.$theme.current('base')
     },
     space() {
       this.$theme.variant('highcontrast')

--- a/docs/router/basics.md
+++ b/docs/router/basics.md
@@ -24,7 +24,7 @@ Each route in this array, is an Object literal that includes the following key p
 - `component` - the Blits component to render for the route. This can be a direct reference, but also a promise or a dynamic import that resolves to a Blits component
 - `hooks` (optional) - hooks such as `before` can be defined to execute code before navigating to the route
 - `options` (optional) - additional options defining route behaviour, such as `keepAlive` and `inHistory`
-- `transitions` (optional) - used to define custom transitions between pages
+- `transition` (optional) - used to define custom transitions between pages
 - `meta` (optional) - an object with arbitrary data associated with a route (like `auth: true/false`, a route ID or route description). Not reactive or passed as props to a component. Available in the `before` and `beforeEach` router hooks.
 
 ### Route options

--- a/docs/router/hooks.md
+++ b/docs/router/hooks.md
@@ -4,8 +4,6 @@ The Blits router supports hooks that allow you to execute code at specific point
 
 Hooks are defined per route in the optional `hooks` key within the Route configuration object.
 
-> Currently, the Blits router only supports the before hook, with additional hooks planned for future releases.
-
 ## Before hook
 
 The before hook is executed before the navigation occurs. It can be used for checks, such as verifying user authentication for a specific route, for pre-fetching data, or for executing logic like sending stats beacons.
@@ -36,9 +34,9 @@ The before hook can optionally return a value, which will influence the behaviou
 - when a `string` is returned, the router will interpret this as a _new route path to redirect to_
 - when an `object` is returned, the router will interpret this as a route object, allowing to _modify (or completely replace) the route object_ being navigated to
 
-Returning an `object` is a simple, yet powerful, mechanism to add advanced runtime configuration to your routes. A common scenario is to overwrite certain parts of the route object provided in the `to`-argument, such as the route options (such as `inHistory` or `stayAlive`) or define conditional page transitions.
+Returning an `object` is a simple, yet powerful, mechanism to add advanced runtime configuration to your routes. A common scenario is to overwrite certain parts of the route object provided in the `to`-argument, such as the route options (such as `inHistory` or `keepAlive`) or define conditional page transitions.
 
-It's also possible to add custom data to the route object in the `key` object. Custom data should be an object literal. When the new page loads, the keys in the `data` object are injected into the Component as `props`.
+It's also possible to add custom data to the route object in the `data` object. Custom data should be an object literal. When the new page loads, the keys in the `data` object are injected into the Component as `props`.
 
 ```js
 export default Blits.Application({
@@ -110,11 +108,11 @@ The `beforeEach`-hooks functions the same as the `before`-hook. It receives the 
 
 The `init`-hook is a router hook that will be invoked once when defined when the router is being instantiated. It can be used to do some onetime setup, required before starting the routing.
 
-The `init`-hook can be an asynchronous function. In this case the router will await the init function to resolve before comencing the first navigation.
+The `init`-hook can be an asynchronous function. In this case the router will await the init function to resolve before commencing the first navigation.
 
 ### `error()`
 
-The `error`-hook is a router hook that will be invoked when an error has occured. For example when routing to a non-existing route. It will receive an error message and the developer is free to implement any error handling functionality in this hook. This can be showing an Error popup, or navigating to a predefined 404 Not found route using the `this.$router.to()` method.
+The `error`-hook is a router hook that will be invoked when an error has occurred. For example when routing to a non-existing route. It will receive an error message and the developer is free to implement any error handling functionality in this hook. This can be showing an Error popup, or navigating to a predefined 404 Not found route using the `this.$router.to()` method.
 
 
 ```js

--- a/docs/router/transitions.md
+++ b/docs/router/transitions.md
@@ -49,7 +49,7 @@ The transition is defined by a _Transition_ object, consisting of:
 - `prop` - the property to apply the transition on
 - `value` - the value to transition to
 - `duration` (optional) - the duration of the transition in milliseconds (defaults to `300ms`)
-- `easing` (optional) - the easing function applied to the transition (defaults to `ease-in`)
+- `easing` (optional) - the easing function applied to the transition (defaults to `ease`)
 
 ```js
 const pageTransition = {
@@ -105,7 +105,7 @@ Similar to the `in`-transition, the `out`-transition is defined by a _Transition
 - `prop` - the property to apply the transition on
 - `value` - the value to transition to
 - `duration` (optional) - the duration of the transition in milliseconds (defaults to `300ms`)
-- `easing` (optional) - the easing function applied to the transition (defaults to `ease-in`)
+- `easing` (optional) - the easing function applied to the transition (defaults to `ease`)
 
 And in order to transition multiple properties at the same time during the _out_ transition, an Array of transition objects can be supplied.
 

--- a/docs/shaders/canvas-shadertypes.md
+++ b/docs/shaders/canvas-shadertypes.md
@@ -68,7 +68,7 @@ export const Rounded = {
       quad.ty,
       quad.width,
       quad.height,
-      this.computed.radius!,
+      this.computed.radius,
     );
     ctx.clip(path);
     //renders node context(if not called the context won't be drawn)

--- a/docs/shaders/v2-conversion-guide.md
+++ b/docs/shaders/v2-conversion-guide.md
@@ -89,7 +89,7 @@ For example if you have a tile with `radius` and an image and a `linearGradient`
 You can also nest `shader` attributes:
 
 ```xml
-<Element shader="{type: 'holePunch', ...props" rtt="true">
+<Element shader="{type: 'holePunch', ...props}" rtt="true">
   <Element src="./image.jpg" shader="{type: 'LinearGradient', ...props}"/>
 </Element>
 ```

--- a/docs/shaders/webgl-shadertypes.md
+++ b/docs/shaders/webgl-shadertypes.md
@@ -123,7 +123,7 @@ export const ColorBurn = {
 
     void main() {
       vec4 color = texture2D(u_texture, v_textureCoords);
-      gl_FragColor = 1.0 - (1.0 - texture) / u_color;
+      gl_FragColor = 1.0 - (1.0 - color) / u_color;
     }
   `
 }

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -112,7 +112,7 @@
       },
       {
         "text": "Layout",
-        "link": "/built-in/layout.md"
+        "link": "/built-in/layout"
       }
     ]
   },

--- a/docs/transitions_animations/transitions.md
+++ b/docs/transitions_animations/transitions.md
@@ -22,6 +22,7 @@ export default Blits.Component('Gold', {
       this.y = this.y + 50
     }
   },
+})
 ```
 
 Using _transitions_ we really make our App come alive.
@@ -47,11 +48,12 @@ export default Blits.Component('Gold', {
       this.y = this.y + 50
     }
   },
+})
 ```
 
 If we try out the modified example above, you'll notice how much difference adding a simple transition makes.
 
-When the `.transition`-modifier is added to a reactive attribute, a default `ease-in` transition with a duration of `300ms` is applied
+When the `.transition`-modifier is added to a reactive attribute, a default `ease` transition with a duration of `300ms` is applied
 
 ## Customizing transitions
 
@@ -86,6 +88,7 @@ Besides a reference to the `value`, you can also use dynamic values for the othe
 
 ### Available easing functions
 
+- `ease` (default)
 - `ease-in`
 - `ease-out`
 - `ease-in-out`
@@ -126,6 +129,7 @@ export default Blits.Component('Gold', {
       //
     },
   }
+})
 ```
 
 It is also possible to keep track of the entire progress of a transition. Every frametick during a transition (ideally once every 16ms), the renderer reports the progress of the transition. You can hook into this event by specifying a `progress` key on the transition configuration object, with a function to excute.
@@ -147,4 +151,5 @@ export default Blits.Component('Gold', {
       }
     },
   }
+})
 ```


### PR DESCRIPTION
Documentation fixes regarding v2 inaccuracies, broken code examples, and typos. Some important changes: 

- `this.parent` -> `this.$parent` in v2 (`user_input.md`, `utility_methods.md`)
- Default transition easing value should be `ease` instead of `ease-in`. Also added `ease` to the easing functions list where it was missing (`transitions.md`, `router/transitions.md`)
- `stayAlive` -> `keepAlive` in router before-hook docs
- `transitions` -> `transition` in route config (`router/basics.md`)
- `width`/`height` aliases marked v1-only, removed in v2 (`element_attributes.md`)
- `effects` launch setting marked as removed in v2, use `shaders` (`settings.md`)
- `wordwrap` marked as fully removed in v2, not just deprecated (`displaying_text.md`)
- Images render at natural dimensions without `w`/`h`; old text said they won't render at all (`displaying_images.md`)
- `$$language.get()` -> `$$language.translate()` (`language.md`)
- Color values in the hover example were JS number literals (`0x4488ff`), which the color setter ignores. Changed to CSS strings (`mouse_support.md`)
- Router custom data goes in the `data` object, not `key` (`router/hooks.md`)
- Application settings added to docsify sidebar; was in `sidebar.json` but missing from `_sidebar.md`

Also fixed broken code examples (missing closing brackets, wrong variable names, wrong method signatures), typos, and minor formatting issues across several files.
