### PR TITLE
apply reactive :color to custom component holders

### DIFF
--- a/src/lib/codegenerator/generator.js
+++ b/src/lib/codegenerator/generator.js
@@ -225,7 +225,6 @@ const generateElementCode = function (
     const value = templateObject[key]
 
     if (isReactiveKey(key)) {
-      if (options.holder && key === ':color') return
       if (options.holder) {
         this.effectsCode.push(`
         if(typeof skips === 'undefined' || (typeof skips[${counter}] === 'undefined' ||


### PR DESCRIPTION
Fix reactive :color on custom components by generating holder updates the same way as other reactive attributes (removes the codegen skip that broke backgrounds.