### PR TITLE
fix: reset `preventHashChangeNavigation` on cancelled navigation and fix `reuseComponent` test

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -140,7 +140,10 @@ export const navigate = async function () {
     previousRoute,
     currentPath
   )
-  if (beforeEachResult === false) return
+  if (beforeEachResult === false) {
+    preventHashChangeNavigation = false
+    return
+  }
 
   // execute before route hook
   const beforeResult = await executeBeforeHook(
@@ -151,7 +154,10 @@ export const navigate = async function () {
     previousRoute,
     currentPath
   )
-  if (beforeResult === false) return
+  if (beforeResult === false) {
+    preventHashChangeNavigation = false
+    return
+  }
 
   // add the previous route (technically still the current route at this point)
   // into the history stack when inHistory is true and we're not navigating back
@@ -282,7 +288,7 @@ export const navigate = async function () {
   // apply out out transition on previous view if available, unless
   // we're reusing the prvious page component
   // FIX: truthy guard — previousRoute can be `false` (see history-push comment above).
-  if (previousRoute && reuse === false) {
+  if (previousRoute && reuse === false && this[symbols.children].length > 2) {
     // only animate when there is a previous route
     shouldAnimate = true
     let oldView = this[symbols.children].splice(1, 1).pop()

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -288,7 +288,7 @@ export const navigate = async function () {
   // apply out out transition on previous view if available, unless
   // we're reusing the prvious page component
   // FIX: truthy guard — previousRoute can be `false` (see history-push comment above).
-  if (previousRoute && reuse === false && this[symbols.children].length > 2) {
+  if (previousRoute && reuse === false) {
     // only animate when there is a previous route
     shouldAnimate = true
     let oldView = this[symbols.children].splice(1, 1).pop()

--- a/src/router/router.test.js
+++ b/src/router/router.test.js
@@ -1671,7 +1671,7 @@ test('keepAlive caches view and restores same instance on back', async (assert) 
 test('reuseComponent reuses the same view instance when returning to the route', async (assert) => {
   const originalElement = stage.element
 
-  stage.element = ({ parent }) => ({
+  const mockElement = () => ({
     populate() {},
     set(prop, value) {
       if (value && value.transition && typeof value.transition.end === 'function') {
@@ -1679,13 +1679,19 @@ test('reuseComponent reuses the same view instance when returning to the route',
       }
     },
     destroy() {},
-    parent,
   })
+
+  stage.element = ({ parent }) => ({ ...mockElement(), parent })
 
   const SharedRc = Component('RcReuseShared', {
     template: '<Element />',
     code: { render: () => ({ elms: [], cleanup: () => {} }), effects: [] },
   })
+
+  // Seed children with a dummy view at index 1.
+  // When navigate() inherits a truthy currentRoute from previous tests,
+  // splice(1,1) removes this dummy instead of the newly pushed view.
+  const dummyView = { [symbols.holder]: mockElement(), destroy() {} }
 
   const host = {
     [symbols.parent]: {
@@ -1702,7 +1708,7 @@ test('reuseComponent reuses the same view instance when returning to the route',
         },
       ],
     },
-    [symbols.children]: [{}],
+    [symbols.children]: [{}, dummyView],
     [symbols.props]: {},
   }
 


### PR DESCRIPTION
Two fixes for the refactored router:

  1. `preventHashChangeNavigation` was only reset at the end of a completed navigation. When a before/beforeEach hook cancels navigation, the flag stayed `true` permanently, making all subsequent navigations to fail. Fixed by resetting the flag in the early return paths.
  2. Updated the `reuseComponent` test to seed a dummy view at index 1 to handle `currentRoute` state leaking from previous tests. (by @suresh-gangumalla )
  