### PR TITLE
fix: typing of computed props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -623,24 +623,36 @@ declare module '@lightningjs/blits' {
     [K in keyof T]: InferProp<T[K]>
   }
 
+  type Computed<T extends Record<string, () => any>> = {
+    [K in keyof T]: Readonly<ReturnType<T[K]>>
+  }
+
   export type ComponentContext<
     P extends Record<string, any>,
     S,
     M,
-    C
-  > = ThisType<Readonly<InferProps<P>> & S & M & Readonly<C> & ChildComponentBase>
+    C extends Record<string, () => any>,
+  > = ThisType<
+    Readonly<InferProps<P>> & S & M & Computed<C> & ChildComponentBase
+  >
 
   export type ApplicationContext<
     P extends Record<string, any>,
     S,
     M,
-    C
-  > = ThisType<Readonly<InferProps<P>> & S & M & Readonly<C> & ApplicationBase>
+    C,
+  > = ThisType<Readonly<InferProps<P>> & S & M & Computed<C> & ApplicationBase>
 
-  export interface ComponentConfig<P extends Props = {}, S, M, C, W> {
+  export interface ComponentConfig<
+    P extends Props = {},
+    S,
+    M,
+    C extends Record<string, () => any>,
+    W,
+  > {
     components?: {
-        [key: string]: ComponentFactory,
-    },
+      [key: string]: ComponentFactory
+    }
     /**
      * XML-based template string of the Component
      *
@@ -1340,7 +1352,7 @@ declare module '@lightningjs/blits' {
   }
 
   interface Computed {
-    [key: string]: any
+    [key: string]: () => any
   }
 
 


### PR DESCRIPTION
Because computed properties are seen as functions in TS rather than the return type of those functions, our codebase is becoming littered with `// @ts-expect-error` comments whenever an operation is performed on a computed prop which does not make sense for a function, such as an arithmetic operation.  This is problematic because it can easily hide "real" errors and makes a mess of the codebase.

Take the following component:

```ts
import Blits from '@lightningjs/blits'

export default Blits.Component('Add', {
    template: `
        <Element>
            <Text content="$result" />
        </Element>
`,
    methods: {
        result() {
            return this.one + 1
        }
    },
    computed: {
        one() {
            return 1
        }
    }
})
```

With the current Blits typing of `computed`, this will result in the following type error:

`Operator '+' cannot be applied to types '() => 1' and 'number'.`.

After the changes in this PR, `this.one` resolves to `1` in TS, rather than `() => 1`, which is what we want and indeed what we get at runtime.

**NOTE:** This change may cause repos to fail linting due to the `// @ts-expect-error` becoming redundant, depending on how the linting rules are configured.  But given that the fix is to simply remove those comments, I think that's definitely a price worth paying!