### PR TITLE
feat(L3): expose renderer platform abstraction via `settings.platform`

### DIFF
--- a/docs/essentials/settings.md
+++ b/docs/essentials/settings.md
@@ -71,11 +71,13 @@ Example font object:
 |----------------|-----------|-------------|
 | `renderMode`   | `'webgl' \| 'canvas'` | Renderer mode (default: 'webgl') |
 | `canvas`       | `HTMLCanvasElement` | Custom canvas to render to |
-| `platform`     | `'web' \| 'next' \| 'chrome50' \| 'legacy'` | Platform abstraction layer used by the Lightning renderer (default: `'web'`) |
+| `platform`     | `'web' \| 'next' \| 'chrome50' \| 'legacy' \| Platform` | Platform abstraction layer used by the Lightning renderer (default: `'web'`) |
 
 ### Platform
 
 The `platform` setting selects which platform abstraction the underlying Lightning renderer uses to talk to the browser (image loading, canvas creation, etc.). Most Apps should leave this unset and use the default `web` platform; the alternatives exist for environments where the modern browser APIs aren't fully available.
+
+You can pass either a **string alias** (recommended) or a **`Platform` class reference** imported directly from `@lightningjs/renderer/platforms` for full control (including custom subclasses).
 
 | Value      | Browser engine |
 |------------|-------------|
@@ -84,12 +86,23 @@ The `platform` setting selects which platform abstraction the underlying Lightni
 | `chrome50` | Chrome 50+ |
 | `legacy`   | Chrome 40+ |
 
-Example:
+Example using a string alias:
 ```js
 Blits.Launch(App, 'app', {
   w: 1920,
   h: 1080,
   platform: 'legacy',
+})
+```
+
+Example passing a class reference:
+```js
+import { WebPlatformChrome50 } from '@lightningjs/renderer/platforms'
+
+Blits.Launch(App, 'app', {
+  w: 1920,
+  h: 1080,
+  platform: WebPlatformChrome50,
 })
 ```
 

--- a/docs/essentials/settings.md
+++ b/docs/essentials/settings.md
@@ -71,6 +71,27 @@ Example font object:
 |----------------|-----------|-------------|
 | `renderMode`   | `'webgl' \| 'canvas'` | Renderer mode (default: 'webgl') |
 | `canvas`       | `HTMLCanvasElement` | Custom canvas to render to |
+| `platform`     | `'web' \| 'next' \| 'chrome50' \| 'legacy'` | Platform abstraction layer used by the Lightning renderer (default: `'web'`) |
+
+### Platform
+
+The `platform` setting selects which platform abstraction the underlying Lightning renderer uses to talk to the browser (image loading, canvas creation, etc.). Most Apps should leave this unset and use the default `web` platform; the alternatives exist for environments where the modern browser APIs aren't fully available.
+
+| Value      | Browser engine |
+|------------|-------------|
+| `web` | Chrome 70+ |
+| `next`     | Chrome 70+ |
+| `chrome50` | Chrome 50+ |
+| `legacy`   | Chrome 40+ |
+
+Example:
+```js
+Blits.Launch(App, 'app', {
+  w: 1920,
+  h: 1080,
+  platform: 'legacy',
+})
+```
 
 ## Effects & Shaders
 
@@ -118,5 +139,6 @@ Blits.Launch(App, 'app', {
   inspector: false,
   announcer: true,
   enableMouse: false, // set true for hover + click-to-focus on canvas
+  platform: 'web', // 'web' (default) | 'next' | 'chrome50' | 'legacy'
 })
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1226,14 +1226,26 @@ declare module '@lightningjs/blits' {
     /**
      * Selects the platform abstraction layer used by the Lightning renderer.
      *
-     * - `web` (default) - Modern browsers with full `createImageBitmap` support
-     * - `next` - PWAs / Service Worker environments using the Fetch API for image loading
-     * - `chrome50` - Older Chromium / WPEWebKit 2017 with basic `createImageBitmap` support
-     * - `legacy` - QtWebKit and other legacy engines with limited browser APIs
+     * Accepts either:
+     * - A string alias for one of the bundled implementations:
+     *   - `web` (default) - Modern browsers with full `createImageBitmap` support
+     *   - `next` - PWAs / Service Worker environments using the Fetch API for image loading
+     *   - `chrome50` - Older Chromium / WPEWebKit 2017 with basic `createImageBitmap` support
+     *   - `legacy` - QtWebKit and other legacy engines with limited browser APIs
+     * - A `Platform` class reference imported from `@lightningjs/renderer/platforms`
+     *   (or a custom subclass) for full control over the platform implementation.
      *
      * When omitted, the renderer falls back to `WebPlatform`.
+     *
+     * @example
+     * ```js
+     * import { WebPlatformChrome50 } from '@lightningjs/renderer/platforms'
+     *
+     * Blits.Launch(App, 'app', { platform: WebPlatformChrome50 })
+     * Blits.Launch(App, 'app', { platform: 'chrome50' }) // equivalent
+     * ```
      */
-    platform?: Platforms,
+    platform?: Platforms | (new (...args: any[]) => any),
 
     /**
      * The time, in milliseconds, after which Blits considers a key press a _hold_ key press

--- a/index.d.ts
+++ b/index.d.ts
@@ -1003,6 +1003,7 @@ declare module '@lightningjs/blits' {
 
   type ReactivityModes = 'Proxy' | 'defineProperty'
   type RenderModes = 'webgl' | 'canvas'
+  type Platforms = 'web' | 'next' | 'chrome50' | 'legacy'
 
     /**
    * Settings
@@ -1221,6 +1222,18 @@ declare module '@lightningjs/blits' {
      * Defaults to `webgl`
      */
     renderMode?: RenderModes,
+
+    /**
+     * Selects the platform abstraction layer used by the Lightning renderer.
+     *
+     * - `web` (default) - Modern browsers with full `createImageBitmap` support
+     * - `next` - PWAs / Service Worker environments using the Fetch API for image loading
+     * - `chrome50` - Older Chromium / WPEWebKit 2017 with basic `createImageBitmap` support
+     * - `legacy` - QtWebKit and other legacy engines with limited browser APIs
+     *
+     * When omitted, the renderer falls back to `WebPlatform`.
+     */
+    platform?: Platforms,
 
     /**
      * The time, in milliseconds, after which Blits considers a key press a _hold_ key press

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.4.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@lightningjs/renderer": "^3.0.3",
+        "@lightningjs/renderer": "^3.0.5",
         "magic-string": "^0.30.21"
       },
       "bin": {
@@ -752,9 +752,9 @@
       }
     },
     "node_modules/@lightningjs/renderer": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@lightningjs/renderer/-/renderer-3.0.3.tgz",
-      "integrity": "sha512-DKvQsesjjGZCDAyG/mK40V9sm+L8KYassB9HJGOvBcA/EOdNwYIcOvsLddMYVJBCttRvgqzgMZBSW3dQyuk31w==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@lightningjs/renderer/-/renderer-3.0.5.tgz",
+      "integrity": "sha512-r/LFj8MmskZXC434okkV8CdTm3B7z9leb6aXVksvkWrLgBGxARTyTt7dIH9/Ho3GxIN9Eu/7QfN742K4tHfe+Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 18.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "tape": "^5.5.0"
   },
   "dependencies": {
-    "@lightningjs/renderer": "^3.0.3",
+    "@lightningjs/renderer": "^3.0.5",
     "magic-string": "^0.30.21"
   },
   "repository": {

--- a/src/engines/L3/launch.js
+++ b/src/engines/L3/launch.js
@@ -113,7 +113,10 @@ export default (App, target, settings = {}) => {
         textureMemory: textureMemorySettings(settings),
         createImageBitmapSupport: 'auto',
         targetFPS: 'maxFPS' in settings ? settings.maxFPS : 0,
-        platform: PLATFORMS[settings.platform] || WebPlatform,
+        platform:
+          typeof settings.platform === 'function'
+            ? settings.platform
+            : PLATFORMS[settings.platform] || WebPlatform,
       },
       ...(settings.advanced || {}),
     },

--- a/src/engines/L3/launch.js
+++ b/src/engines/L3/launch.js
@@ -19,6 +19,12 @@ import { RendererMain } from '@lightningjs/renderer'
 import { WebGlCoreRenderer, SdfTextRenderer } from '@lightningjs/renderer/webgl'
 import { CanvasCoreRenderer, CanvasTextRenderer } from '@lightningjs/renderer/canvas'
 import { Inspector } from '@lightningjs/renderer/inspector'
+import {
+  WebPlatform,
+  WebPlatformNext,
+  WebPlatformChrome50,
+  WebPlatformLegacy,
+} from '@lightningjs/renderer/platforms'
 
 import { Log } from '../../lib/log.js'
 import { SCREEN_RESOLUTIONS, RENDER_QUALITIES } from '../../constants.js'
@@ -41,6 +47,13 @@ const textRenderEngines = (settings) => {
 
   if (renderMode === 'webgl') return [SdfTextRenderer, CanvasTextRenderer]
   if (renderMode === 'canvas') return [CanvasTextRenderer]
+}
+
+const PLATFORMS = {
+  web: WebPlatform,
+  next: WebPlatformNext,
+  chrome50: WebPlatformChrome50,
+  legacy: WebPlatformLegacy,
 }
 
 const textureMemorySettings = (settings) => {
@@ -100,7 +113,7 @@ export default (App, target, settings = {}) => {
         textureMemory: textureMemorySettings(settings),
         createImageBitmapSupport: 'auto',
         targetFPS: 'maxFPS' in settings ? settings.maxFPS : 0,
-        platform: 'platform' in settings ? settings.platform : null,
+        platform: PLATFORMS[settings.platform] || WebPlatform,
       },
       ...(settings.advanced || {}),
     },

--- a/src/launch.js
+++ b/src/launch.js
@@ -83,6 +83,7 @@ async function rendererVersion() {
  * @property {number} [gpuMemoryLimit] - Threshold after which textures are freed (deprecated)
  * @property {object} [gpuMemory] - Configures the gpu memory settings
  * @property {"webgl"|"canvas"} [renderMode] - Defines which mode the renderer should operate in
+ * @property {"web"|"next"|"chrome50"|"legacy"} [platform] - Platform abstraction layer used by the renderer
  * @property {number} [holdTimeout] - Time after which a key press is considered a hold
  * @property {HTMLCanvasElement} [canvas] - Custom canvas object used to render the App
  * @property {number} [textureProcessingTimeLimit] - Max time renderer can process textures in a frame

--- a/src/launch.js
+++ b/src/launch.js
@@ -83,7 +83,7 @@ async function rendererVersion() {
  * @property {number} [gpuMemoryLimit] - Threshold after which textures are freed (deprecated)
  * @property {object} [gpuMemory] - Configures the gpu memory settings
  * @property {"webgl"|"canvas"} [renderMode] - Defines which mode the renderer should operate in
- * @property {"web"|"next"|"chrome50"|"legacy"} [platform] - Platform abstraction layer used by the renderer
+ * @property {"web"|"next"|"chrome50"|"legacy"|Function} [platform] - Platform abstraction layer used by the renderer. Either a string alias or a `Platform` class from `@lightningjs/renderer/platforms`
  * @property {number} [holdTimeout] - Time after which a key press is considered a hold
  * @property {HTMLCanvasElement} [canvas] - Custom canvas object used to render the App
  * @property {number} [textureProcessingTimeLimit] - Max time renderer can process textures in a frame


### PR DESCRIPTION
## Summary

Adds a new top-level `platform` setting to `Blits.Launch` that lets apps pick
the platform abstraction layer used by the underlying Lightning renderer.

The renderer ships four implementations under `@lightningjs/renderer/platforms`
(`WebPlatform`, `WebPlatformNext`, `WebPlatformChrome50`, `WebPlatformLegacy`).

Until now Blits always fell back to the default `WebPlatform`.

## Usage

```js
Blits.Launch(App, 'app', {
  w: 1920,
  h: 1080,
  platform: 'legacy', // 'web' (default) | 'next' | 'chrome50' | 'legacy'
})