### PR TITLE
Feature/prevent cleanup attribute

### DIFF
--- a/src/engines/L3/element.js
+++ b/src/engines/L3/element.js
@@ -318,10 +318,8 @@ const propsTransformer = {
     const resizeMode = {}
 
     if (v === 'cover' || v === 'contain') {
-      this.props['textureOptions'] = {
-        ...this.props.props['textureOptions'],
-        resizeMode: { type: v },
-      }
+      const opts = this.props.props['textureOptions'] || (this.props.props['textureOptions'] = {})
+      opts['resizeMode'] = { type: v }
       return
     }
 
@@ -336,7 +334,8 @@ const propsTransformer = {
         resizeMode['clipX'] = 'x' in v.position === true ? v.position.x : null
         resizeMode['clipY'] = 'y' in v.position === true ? v.position.y : null
       }
-      this.props['textureOptions'] = { ...this.props.props['textureOptions'], resizeMode }
+      const opts = this.props.props['textureOptions'] || (this.props.props['textureOptions'] = {})
+      opts['resizeMode'] = resizeMode
     }
   },
   /**
@@ -356,10 +355,8 @@ const propsTransformer = {
    * @param {boolean} v
    */
   set preventCleanup(v) {
-    this.props['textureOptions'] = {
-      ...this.props.props['textureOptions'],
-      preventCleanup: v === true,
-    }
+    const opts = this.props.props['textureOptions'] || (this.props.props['textureOptions'] = {})
+    opts['preventCleanup'] = v === true
   },
   set rtt(v) {
     this.props['rtt'] = v

--- a/src/engines/L3/element.js
+++ b/src/engines/L3/element.js
@@ -318,7 +318,10 @@ const propsTransformer = {
     const resizeMode = {}
 
     if (v === 'cover' || v === 'contain') {
-      this.props['textureOptions'] = { resizeMode: { type: v } }
+      this.props['textureOptions'] = {
+        ...this.props.props['textureOptions'],
+        resizeMode: { type: v },
+      }
       return
     }
 
@@ -333,7 +336,29 @@ const propsTransformer = {
         resizeMode['clipX'] = 'x' in v.position === true ? v.position.x : null
         resizeMode['clipY'] = 'y' in v.position === true ? v.position.y : null
       }
-      this.props['textureOptions'] = { resizeMode }
+      this.props['textureOptions'] = { ...this.props.props['textureOptions'], resizeMode }
+    }
+  },
+  /**
+   * Prevents the texture from being cleaned up when it is no longer rendered.
+   *
+   * @remarks
+   * When set to `true`, the texture associated with this element will be kept
+   * in GPU memory indefinitely, even when the element is off-screen or under
+   * memory pressure. This is useful for textures that are frequently reused
+   * and should always be instantly available without any reload delay.
+   *
+   * Use with care: textures marked as persistent consume GPU memory permanently
+   * and are never freed by the automatic cleanup cycle.
+   *
+   * @defaultValue `false`
+   *
+   * @param {boolean} v
+   */
+  set preventCleanup(v) {
+    this.props['textureOptions'] = {
+      ...this.props.props['textureOptions'],
+      preventCleanup: v === true,
     }
   },
   set rtt(v) {

--- a/src/engines/L3/element.test.js
+++ b/src/engines/L3/element.test.js
@@ -392,6 +392,97 @@ test('Element - Set `fit` property should not set not required keys', (assert) =
   assert.end()
 })
 
+test('Element - Set `preventCleanup` property to true', (assert) => {
+  assert.capture(renderer, 'createNode', () => new EventEmitter())
+  const el = createElement()
+
+  el.set('preventCleanup', true)
+
+  assert.ok(el.node['textureOptions'] instanceof Object, 'textureOptions should be an object')
+  assert.equal(
+    el.node['textureOptions']['preventCleanup'],
+    true,
+    'Node textureOptions.preventCleanup should be true'
+  )
+  assert.equal(
+    el.props.props['textureOptions']['preventCleanup'],
+    true,
+    'Props textureOptions.preventCleanup should be set to true'
+  )
+  assert.equal(el.props.raw['preventCleanup'], true, "Props' raw map entry should be added")
+  assert.end()
+})
+
+test('Element - Set `preventCleanup` property to false', (assert) => {
+  assert.capture(renderer, 'createNode', () => new EventEmitter())
+  const el = createElement()
+
+  el.set('preventCleanup', false)
+
+  assert.ok(el.node['textureOptions'] instanceof Object, 'textureOptions should be an object')
+  assert.equal(
+    el.node['textureOptions']['preventCleanup'],
+    false,
+    'Node textureOptions.preventCleanup should be false'
+  )
+  assert.equal(
+    el.props.props['textureOptions']['preventCleanup'],
+    false,
+    'Props textureOptions.preventCleanup should be set to false'
+  )
+  assert.end()
+})
+
+test('Element - Set `fit` and `preventCleanup` together preserves both in textureOptions', (assert) => {
+  assert.capture(renderer, 'createNode', () => new EventEmitter())
+  const el = createElement()
+
+  el.set('fit', 'cover')
+  el.set('preventCleanup', true)
+
+  assert.ok(el.node['textureOptions'] instanceof Object, 'textureOptions should be an object')
+  assert.ok(
+    el.node['textureOptions']['resizeMode'] instanceof Object,
+    'resizeMode should be preserved after setting preventCleanup'
+  )
+  assert.equal(
+    el.node['textureOptions']['resizeMode']['type'],
+    'cover',
+    'Node resizeMode.type should still be "cover" after setting preventCleanup'
+  )
+  assert.equal(
+    el.node['textureOptions']['preventCleanup'],
+    true,
+    'Node textureOptions.preventCleanup should be true after setting fit'
+  )
+  assert.end()
+})
+
+test('Element - Set `preventCleanup` then `fit` preserves both in textureOptions', (assert) => {
+  assert.capture(renderer, 'createNode', () => new EventEmitter())
+  const el = createElement()
+
+  el.set('preventCleanup', true)
+  el.set('fit', 'contain')
+
+  assert.ok(el.node['textureOptions'] instanceof Object, 'textureOptions should be an object')
+  assert.equal(
+    el.node['textureOptions']['preventCleanup'],
+    true,
+    'Node textureOptions.preventCleanup should be preserved after setting fit'
+  )
+  assert.ok(
+    el.node['textureOptions']['resizeMode'] instanceof Object,
+    'resizeMode should be set after setting fit'
+  )
+  assert.equal(
+    el.node['textureOptions']['resizeMode']['type'],
+    'contain',
+    'Node resizeMode.type should be "contain"'
+  )
+  assert.end()
+})
+
 test('Element - Set `placement` property with value `center`', (assert) => {
   assert.capture(renderer, 'createNode', () => new EventEmitter())
   const el = createElement()

--- a/vscode/data/template-attributes.json
+++ b/vscode/data/template-attributes.json
@@ -470,6 +470,22 @@
       "Element"
     ]
   },
+  "preventCleanup": {
+    "attrType": "regular",
+    "types": [
+      "enum"
+    ],
+    "values": [
+      "true",
+      "false"
+    ],
+    "defaultValue": "false",
+    "reactive": false,
+    "description": "Prevents the texture from being freed by the GPU memory cleanup cycle. Set to true for frequently reused textures that must always be instantly available without any reload delay. Use with care: persistent textures consume GPU memory permanently.",
+    "usedIn": [
+      "Element"
+    ]
+  },
   "rtt": {
     "attrType": "regular",
     "types": [


### PR DESCRIPTION
Exposes the renderer's `textureOptions.preventCleanup` flag as a first-class `preventCleanup` attribute on Blits `<Element>` nodes.

When set to `true`, the underlying renderer texture is never evicted from GPU memory by the automatic cleanup cycle, regardless of whether the element is on-screen or under memory pressure. Useful for frequently reused textures (e.g. persistent backgrounds, shared UI chrome) that must always be instantly available without a reload delay.

## Usage
```
<Element src="assets/bg.png" preventCleanup="true" />
<Element src="assets/bg.png" fit="cover" preventCleanup="true" />
<Element :src="$imageUrl" :preventCleanup="$isPersistent" />
```