### PR TITLE
Fixes browser cache handling for generated msdf files

### DIFF
--- a/vite/msdfGenerator.js
+++ b/vite/msdfGenerator.js
@@ -145,12 +145,20 @@ export default function () {
 
               if (fs.existsSync(generatedFontFile)) {
                 const fileContent = fs.readFileSync(generatedFontFile)
+                const etag = `"${generateHash(generatedFontFile)}"`
 
                 // Check if headers have already been sent
                 if (!res.headersSent) {
                   res.setHeader('Content-Type', mimeType)
-                  res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
-                  res.end(fileContent)
+                  res.setHeader('Cache-Control', 'no-cache')
+                  res.setHeader('ETag', etag)
+
+                  if (req.headers['if-none-match'] === etag) {
+                    res.statusCode = 304
+                    res.end()
+                  } else {
+                    res.end(fileContent)
+                  }
                 } else {
                   // this should never happen except some edge cases
                   console.error(`ERROR: Headers already sent for ${req.url}`, res.getHeaders())


### PR DESCRIPTION
The dev server's `configureServer` middleware sends `Cache-Control: public, max-age=31536000, immutable` for generated MSDF font files. `immutable` tells the browser the response will never change, so once the files are cached, a normal reload will not request it again even after any change occurs in `.ttf`/`.config.json` files and the plugin regenerates files again server-side. Only a hard reload (empty cache) gets the updated files.

This fix replaces `immutable` with `no-cache` plus `ETag` (content hash). The browser still caches the response but always revalidates: unchanged fonts get served from its own cache via a `304`, changed fonts trigger a full fetch.

I verified manually in blits-example-app: changed a font's `.config.json`, confirmed a normal reload now gets the regenerated atlas automatically, and confirmed a reload with no font changes still returns `HTTP 304` instead of re-download. `Etag` implementation should work even very old browser versions.
