### PR TITLE
fix: default router view, fallback view and warning if two no name ro…

### DIFF
--- a/docs/router/basics.md
+++ b/docs/router/basics.md
@@ -91,6 +91,8 @@ In some cases you may want to have multiple `<RouterView />` components in your 
 
 By assigning a `name` to a `<RouterView />`, you can retrieve a Router instance scoped to that Router view using the `this.$router.get()`-method.
 
+Router view names must be unique and stable for the lifetime of each view. The unnamed RouterView uses the empty string as its name, so an application should have at most one unnamed RouterView. Duplicate or dynamically changed names can cause ambiguous view resolution and shared navigation state.
+
 ```js
 export default Blits.Application({
   template: `
@@ -108,6 +110,8 @@ this.$router.get('modal').to('/modal/details')
 ```
 
 The scoped Router instance has the same methods and properties as `this.$router`. This means you can also use `this.$router.get('modal').back()` to navigate back down the history stack of the named Router view, or use `this.$router.get('modal').currentRoute` to retrieve its current route.
+
+If a named RouterView cannot be found, navigation falls back to the default unnamed RouterView and logs a warning.
 
 ## Navigation
 

--- a/src/component/base/router.js
+++ b/src/component/base/router.js
@@ -67,11 +67,25 @@ const resolveRouterView = (component, routerViewName) => {
     const registeredRouterView = getRegisteredRouterView(routerViewName)
     if (registeredRouterView !== null) return registeredRouterView
 
-    return getRouterView(component, routerViewName)
+    const treeRouterView = getRouterView(component, routerViewName)
+    if (treeRouterView !== null) return treeRouterView
+
+    // Named view not found — fall back to default (unnamed) view
+    const defaultView = getRegisteredRouterView('')
+    if (defaultView !== null) return defaultView
+
+    return getRouterView(component)
   }
 
   const singleRouterView = getSingleRegisteredRouterView()
   if (singleRouterView !== null) return singleRouterView
+
+  // When multiple router views exist and no name was specified,
+  // prefer the default (unnamed) router view before falling back
+  // to tree-walking. This ensures hooks on the App's main router
+  // fire correctly when calling router.to() from a child component.
+  const defaultView = getRegisteredRouterView('')
+  if (defaultView !== null) return defaultView
 
   return getRouterView(component)
 }

--- a/src/component/base/router.js
+++ b/src/component/base/router.js
@@ -16,6 +16,7 @@
  */
 
 import symbols from '../../lib/symbols.js'
+import { Log } from '../../lib/log.js'
 import {
   back,
   currentRoute,
@@ -72,9 +73,20 @@ const resolveRouterView = (component, routerViewName) => {
 
     // Named view not found — fall back to default (unnamed) view
     const defaultView = getRegisteredRouterView('')
-    if (defaultView !== null) return defaultView
+    if (defaultView !== null) {
+      Log.warn(
+        `RouterView "${routerViewName}" was not found. Navigation is falling back to the default RouterView.`
+      )
+      return defaultView
+    }
 
-    return getRouterView(component)
+    const treeDefaultView = getRouterView(component)
+    if (treeDefaultView !== null) {
+      Log.warn(
+        `RouterView "${routerViewName}" was not found. Navigation is falling back to the default RouterView.`
+      )
+    }
+    return treeDefaultView
   }
 
   const singleRouterView = getSingleRegisteredRouterView()

--- a/src/components/RouterView.js
+++ b/src/components/RouterView.js
@@ -79,7 +79,7 @@ export default () =>
           }
         },
         focus() {
-          if (this.activeView && Focus.get() === this) {
+          if (this.active && this.activeView && Focus.get() === this) {
             this.activeView.$focus()
           }
         },

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -81,14 +81,28 @@ const history = []
 const routerViews = new Set()
 let singleRouterView = null
 
-let overrideOptions = {}
-let navigationData = {}
-let navigatingBack = false
-let navigatingBackTo = undefined
-let previousFocus
-// Skips internal router navigation when set to true only for the next "navigate"
-// execution, needed for window.history management
-let preventHashChangeNavigation = false
+// Per-RouterView navigation state keyed by router view name.
+// When multiple router views exist, each view must have its own navigation
+// state so that one view's navigation doesn't interfere with another's hooks.
+const perViewState = new Map()
+
+const getViewState = (name = '') => {
+  if (!perViewState.has(name)) {
+    perViewState.set(name, {
+      overrideOptions: {},
+      navigationData: {},
+      navigatingBack: false,
+      navigatingBackTo: undefined,
+      previousFocus: undefined,
+      preventHashChangeNavigation: false,
+    })
+  }
+  return perViewState.get(name)
+}
+
+const clearViewState = (name = '') => {
+  perViewState.delete(name)
+}
 
 /**
  * Navigate to a route
@@ -103,8 +117,9 @@ let preventHashChangeNavigation = false
  * @returns {Promise<void>}
  */
 export const navigate = async function () {
+  const viewState = getViewState(this.name)
   // early return when in preventHashChange mode
-  if (preventHashChangeNavigation !== false) return
+  if (viewState.preventHashChangeNavigation !== false) return
   // early return when no routes
   if (!this[symbols.parent][symbols.routes] || this[symbols.parent][symbols.routes].length === 0)
     return
@@ -118,7 +133,12 @@ export const navigate = async function () {
 
   const hash = getHash(location.hash, this.name)
   // try to find the route
-  let route = matchHash(hash, this[symbols.parent][symbols.routes], overrideOptions, navigationData)
+  let route = matchHash(
+    hash,
+    this[symbols.parent][symbols.routes],
+    viewState.overrideOptions,
+    viewState.navigationData
+  )
 
   // early return when route not found
   if (route === false) {
@@ -151,10 +171,11 @@ export const navigate = async function () {
     this[symbols.parent],
     route,
     this.previousRoute,
-    currentPath
+    currentPath,
+    viewState
   )
   if (beforeEachResult === false) {
-    preventHashChangeNavigation = false
+    viewState.preventHashChangeNavigation = false
     state.navigating = false
     return
   }
@@ -167,10 +188,11 @@ export const navigate = async function () {
     this[symbols.parent],
     route,
     this.previousRoute,
-    currentPath
+    currentPath,
+    viewState
   )
   if (beforeResult === false) {
-    preventHashChangeNavigation = false
+    viewState.preventHashChangeNavigation = false
     state.navigating = false
     return
   }
@@ -184,7 +206,7 @@ export const navigate = async function () {
     this.previousRoute &&
     this.previousRoute.options &&
     this.previousRoute.options.inHistory === true &&
-    navigatingBack === false
+    viewState.navigatingBack === false
   ) {
     this.history.push(this.previousRoute)
   }
@@ -202,10 +224,10 @@ export const navigate = async function () {
   let view
   let focus
   // when navigating back let's see if we're navigating back to a route that was kept alive
-  if (navigatingBack === true && navigatingBackTo !== undefined) {
-    view = navigatingBackTo.view
-    focus = navigatingBackTo.focus
-    navigatingBackTo = null
+  if (viewState.navigatingBack === true && viewState.navigatingBackTo !== undefined) {
+    view = viewState.navigatingBackTo.view
+    focus = viewState.navigatingBackTo.focus
+    viewState.navigatingBackTo = null
   }
   // merge props with potential route params, navigation data and route data to be injected into the component instance
   const props = {
@@ -284,7 +306,7 @@ export const navigate = async function () {
   }
 
   // keep reference to the previous focus for storing in cache
-  previousFocus = Focus.get()
+  viewState.previousFocus = Focus.get()
 
   const children = this[symbols.children]
   this.activeView = children[children.length - 1]
@@ -313,15 +335,16 @@ export const navigate = async function () {
 
       // Resolve effective keepAlive: runtime override from $router.to() takes precedence
       // over the static route config option
-      const hasOverrideOptions = overrideOptions && typeof overrideOptions === 'object'
+      const hasOverrideOptions =
+        viewState.overrideOptions && typeof viewState.overrideOptions === 'object'
       const keepAlive =
-        hasOverrideOptions && overrideOptions.keepAlive !== undefined
-          ? overrideOptions.keepAlive
+        hasOverrideOptions && viewState.overrideOptions.keepAlive !== undefined
+          ? viewState.overrideOptions.keepAlive
           : this.previousRoute.options && this.previousRoute.options.keepAlive
 
       // cache the page when it's as 'keepAlive' instead of destroying
       if (
-        navigatingBack === false &&
+        viewState.navigatingBack === false &&
         keepAlive === true &&
         this.previousRoute &&
         this.previousRoute.options &&
@@ -330,7 +353,7 @@ export const navigate = async function () {
         const historyItem = this.history[this.history.length - 1]
         if (historyItem !== undefined) {
           historyItem.view = oldView
-          historyItem.focus = previousFocus
+          historyItem.focus = viewState.previousFocus
         }
       }
 
@@ -339,12 +362,12 @@ export const navigate = async function () {
        * 2. Navigating back, and the previous route is configured with "keep alive" set to true.
        * 3. Navigating back, and the previous route is not configured with "keep alive" set to true.
        */
-      if (this.previousRoute.options && (keepAlive !== true || navigatingBack === true)) {
+      if (this.previousRoute.options && (keepAlive !== true || viewState.navigatingBack === true)) {
         oldView.destroy()
         oldView = null
       }
 
-      previousFocus = null
+      viewState.previousFocus = null
     }
   }
 
@@ -363,16 +386,14 @@ export const navigate = async function () {
   // execute after route Hook
   await executeAfterHook(route.hooks, 'after', this[symbols.parent], route, this.previousRoute)
 
-  // Clear module-level variables after removeView has consumed them.
-  // Placed here so it executes for all navigation flows, not only when
-  // previousRoute exists and reuse is false.
-  overrideOptions = {}
-  navigationData = {}
+  // Clear per-view navigation state after navigation is complete.
+  viewState.overrideOptions = {}
+  viewState.navigationData = {}
 
   // reset navigating indicators
-  navigatingBack = false
+  viewState.navigatingBack = false
   state.navigating = false
-  preventHashChangeNavigation = false
+  viewState.preventHashChangeNavigation = false
 }
 
 const setOrAnimate = (element, transition, shouldAnimate = true) => {
@@ -402,7 +423,8 @@ const executeBeforeHook = async function (
   parent,
   route,
   previousRoute,
-  currentPath
+  currentPath,
+  viewState
 ) {
   let result
   if (hooks && hooks[hookName]) {
@@ -417,10 +439,10 @@ const executeBeforeHook = async function (
       Log.error(`Error or Rejected Promise in "${hookName}" Hook`, error)
       this.currentRoute = previousRoute
       if (this.history.length > 0) {
-        preventHashChangeNavigation = true
+        viewState.preventHashChangeNavigation = true
         platform.historyBack()
 
-        navigatingBack = false
+        viewState.navigatingBack = false
         state.navigating = false
       }
       return false
@@ -435,9 +457,9 @@ const executeBeforeHook = async function (
     if (result === false) {
       this.currentRoute = previousRoute
       if (this.history.length > 0) {
-        preventHashChangeNavigation = true
+        viewState.preventHashChangeNavigation = true
         platform.historyBack()
-        navigatingBack = false
+        viewState.navigatingBack = false
         state.navigating = false
       }
       return false
@@ -493,20 +515,34 @@ const executeTransition = async (transition, element, animate) => {
 }
 
 export const to = (path, data = {}, options = {}, routerViewName = '') => {
-  navigationData = data
-  overrideOptions = options
+  const viewState = getViewState(routerViewName)
+  viewState.navigationData = data
+  viewState.overrideOptions = options
 
   setHash(path, routerViewName)
 }
 
 export const toRouterView = (routerView, path, data = {}, options = {}) => {
-  navigationData = data
-  overrideOptions = options
+  const viewState = getViewState(routerView.name)
+  viewState.navigationData = data
+  viewState.overrideOptions = options
 
   setHash(path, routerView.name)
 }
 
 export const registerRouterView = (routerView) => {
+  // Warn when multiple unnamed router views are registered — they must be named
+  // to avoid shared state collisions and ambiguous route resolution.
+  if (routerView.name === '' && routerViews.size > 0) {
+    for (const existing of routerViews) {
+      if (existing.name === '') {
+        Log.warn(
+          'Multiple unnamed RouterViews detected. When using more than one RouterView, each should have a unique "name" prop to ensure correct routing behavior.'
+        )
+        break
+      }
+    }
+  }
   routerViews.add(routerView)
   singleRouterView = routerViews.size === 1 ? routerView : null
 }
@@ -514,6 +550,7 @@ export const registerRouterView = (routerView) => {
 export const unregisterRouterView = (routerView) => {
   routerViews.delete(routerView)
   singleRouterView = routerViews.size === 1 ? routerViews.values().next().value : null
+  clearViewState(routerView.name)
 }
 
 export const getRegisteredRouterView = (name) => {
@@ -531,11 +568,12 @@ export const getSingleRegisteredRouterView = () => {
 
 export const back = function () {
   if (this.history === undefined) return
+  const viewState = getViewState(this.name)
   const route = this.history.pop()
   if (route && this.currentRoute !== route) {
     // set indicator that we are navigating back (to prevent adding page to history stack)
-    navigatingBack = true
-    navigatingBackTo = route
+    viewState.navigatingBack = true
+    viewState.navigatingBackTo = route
     toRouterView(this, route.hash, route.data, route.options)
     return true
   }
@@ -567,8 +605,8 @@ export const back = function () {
     const route = matchHash(
       getHash(path),
       this[symbols.parent][symbols.routes],
-      overrideOptions,
-      navigationData
+      viewState.overrideOptions,
+      viewState.navigationData
     )
 
     if (route && backtrack) {

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -531,16 +531,15 @@ export const toRouterView = (routerView, path, data = {}, options = {}) => {
 }
 
 export const registerRouterView = (routerView) => {
-  // Warn when multiple unnamed router views are registered — they must be named
-  // to avoid shared state collisions and ambiguous route resolution.
-  if (routerView.name === '' && routerViews.size > 0) {
-    for (const existing of routerViews) {
-      if (existing.name === '') {
-        Log.warn(
-          'Multiple unnamed RouterViews detected. When using more than one RouterView, each should have a unique "name" prop to ensure correct routing behavior.'
-        )
-        break
-      }
+  // RouterView names identify both the view and its navigation state, so duplicate
+  // names cause state collisions and ambiguous route resolution.
+  for (const existing of routerViews) {
+    if (existing !== routerView && existing.name === routerView.name) {
+      const name = routerView.name === '' ? 'the default name' : `"${routerView.name}"`
+      Log.warn(
+        `Multiple RouterViews use ${name}. Each RouterView must have a unique and stable "name" prop to ensure correct routing behavior.`
+      )
+      break
     }
   }
   routerViews.add(routerView)

--- a/src/router/router.test.js
+++ b/src/router/router.test.js
@@ -919,20 +919,49 @@ test('this.$router.get(name) targets a named RouterView', async (assert) => {
   registerRouterView(modalRouterView)
 
   try {
-    assert.equal(app.$router.get('modal').to('/modal-first'), true, 'Named to should return true')
+    assert.equal(
+      app.$router.to('/main-first', { source: 'main' }, { navigationId: 'main' }),
+      true,
+      'Default to should return true'
+    )
+    assert.equal(
+      app.$router.get('modal').to('/modal-first', { source: 'modal' }, { navigationId: 'modal' }),
+      true,
+      'Named to should return true'
+    )
+
+    await navigate.call(mainRouterView)
+    assert.equal(
+      mainRouterView.currentRoute.path,
+      '/main-first',
+      'Default to should navigate the local/default RouterView'
+    )
+    assert.equal(
+      mainRouterView.currentRoute.data.source,
+      'main',
+      'Default RouterView should retain its own navigation data'
+    )
+    assert.equal(
+      mainRouterView.currentRoute.options.navigationId,
+      'main',
+      'Default RouterView should retain its own navigation options'
+    )
+
     await navigate.call(modalRouterView)
     assert.equal(
       modalRouterView.currentRoute.path,
       '/modal-first',
       'Named to should navigate the named RouterView'
     )
-
-    assert.equal(app.$router.to('/main-first'), true, 'Default to should return true')
-    await navigate.call(mainRouterView)
     assert.equal(
-      mainRouterView.currentRoute.path,
-      '/main-first',
-      'Default to should navigate the local/default RouterView'
+      modalRouterView.currentRoute.data.source,
+      'modal',
+      'Named RouterView should retain its own navigation data'
+    )
+    assert.equal(
+      modalRouterView.currentRoute.options.navigationId,
+      'modal',
+      'Named RouterView should retain its own navigation options'
     )
 
     app.$router.get('modal').to('/modal-second')


### PR DESCRIPTION
## Summary

This PR fixes several issues that occurred when using multiple `RouterView` instances, particularly around navigation state isolation and router view resolution.

### 1. Per-`RouterView` Navigation State (`src/router/router.js`)

**Problem**

Several navigation-related variables (`overrideOptions`, `navigationData`, `navigatingBack`, `navigatingBackTo`, `previousFocus`, and `preventHashChangeNavigation`) were stored as module-level singletons. Since all `RouterView` instances respond to hash changes, state from one view could inadvertently affect another, causing issues such as skipped `before` hooks or incorrect navigation behaviour.

**Solution**

* Replaced the module-level state with a `Map` (`perViewState`) keyed by router view name.
* Each `RouterView` now retrieves its own isolated state via `getViewState(this.name)`.
* State is automatically cleaned up when a `RouterView` is unregistered.

---

### 2. Default `RouterView` Fallback (`src/component/base/router.js`)

**Problem**

When multiple `RouterView` instances were registered and `router.to()` was called without specifying a view name, `getSingleRegisteredRouterView()` returned `null`. The existing fallback relied on tree traversal, which could resolve to the wrong router view, preventing the application's primary router hooks from executing.

**Solution**

* Added an intermediate lookup for the default (unnamed) `RouterView` (`name === ''`) before falling back to tree traversal.
* This ensures the application's primary router view is selected consistently.

---

### 3. Named `RouterView` Fallback (`src/component/base/router.js`)

**Problem**

Calling `this.$router.get('someName').to(...)` with a non-existent router view name resulted in navigation silently failing because resolution returned `null`.

**Solution**

* If a named router view cannot be found via the registry or tree traversal, navigation now falls back to the default (unnamed) `RouterView` instead of failing.

---

### 4. Warning for Multiple Unnamed `RouterView`s (`src/router/router.js`)

**Problem**

If multiple unnamed `RouterView` instances are registered, they share the same `perViewState` entry and ambiguous routing behaviour, effectively recreating the original issue.

**Solution**

* Added a `Log.warn()` during `registerRouterView()` when a second unnamed `RouterView` is registered.
* The warning advises developers to assign unique `name` props to each `RouterView` to avoid unexpected behaviour.
