### PR TITLE
fix: remove InferProp from InferProps for Props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -642,7 +642,9 @@ declare module '@lightningjs/blits' {
   type InferProp<T> = T extends (...args: any[]) => any ? ReturnType<T> : T
 
   type InferProps<T extends Record<string, any>> = {
-    [K in keyof T]: InferProp<T[K]>
+    // Since InferProps is no longer used for `Computed` props,
+    // then we do not need to infer the return type of a function-typed prop in `Props`.
+    [K in keyof T]: T[K]
   }
 
   type Computed<T extends Record<string, () => any>> = {


### PR DESCRIPTION
#### Problem:
When a prop is defined with a function type (e.g., a callback), `InferProp` applies `ReturnType<T>` to it, making the prop uncallable in the component's `this` context. For example, a prop typed as `((item: Item) => void) | undefined` becomes `void | undefined` on this.

#### Rationale: 
`InferProp` was most likely designed for the old array-format props. The new object-format props use literal defaults. `Computed<C>` already handles its own `ReturnType` extraction independently.