### PR TITLE
fix: address loss of autocomplete in component context

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -653,7 +653,7 @@ declare module '@lightningjs/blits' {
     P extends Record<string, any>,
     S,
     M,
-    C extends Record<string, () => any>,
+    C extends Record<string, () => any> = Record<never, never>,
   > = ThisType<
     Readonly<InferProps<P>> & S & M & Computed<C> & ChildComponentBase
   >
@@ -669,7 +669,7 @@ declare module '@lightningjs/blits' {
     P extends Props = {},
     S,
     M,
-    C extends Record<string, () => any>,
+    C extends Record<string, () => any> = Record<never, never>,
     W,
   > {
     components?: {
@@ -1478,7 +1478,7 @@ declare module '@lightningjs/blits' {
       P extends Props,
       S extends State,
       M extends Methods,
-      C extends Computed,
+      C extends Computed = Record<never, never>,
       W extends Watch>(config: ApplicationConfig<P, S, M, C, W>) : ComponentFactory
       /**
      * Blits Component
@@ -1489,7 +1489,7 @@ declare module '@lightningjs/blits' {
       P extends Props,
       S extends State,
       M extends Methods,
-      C extends Computed,
+      C extends Computed = Record<never, never>,
       W extends Watch>(name: string, config: ComponentConfig<P, S, M, C, W>) : ComponentFactory
     /**
      * Blits Launch


### PR DESCRIPTION
#### Problem:
When a `Blits.Component()` or `Blits.Application()` config object has no `computed` property (or an empty `computed: {}`), TypeScript cannot infer the generic type parameter `C`. It falls back to the constraint `Record<string, () => any>`, which causes `Computed<C>` to produce an index signature `{ [key: string]: Readonly<any> }`. This contaminates the `ThisType<>` intersection, effectively widening this to any inside methods, hooks, input, and watch. All autocomplete and type checking is lost.

```typescript
// ❌ No autocomplete — this: any
Blits.Component('Broken', {
  state() { return { count: 0 } },
  methods: {
    increment() { this.count++ } // ← no autocomplete, no type checking
  }
})

// ❌ Empty computed — still no autocomplete
Blits.Component('StillBroken', {
  state() { return { count: 0 } },
  computed: {},
  methods: {
    increment() { this.count++ } // ← still any
  }
})

// ✅ Works — computed has at least one property
Blits.Component('Works', {
  state() { return { count: 0 } },
  computed: {
    double() { return this.count * 2 }
  },
  methods: {
    increment() { this.count++ } // ← fully typed
  }
})
```