### PR TITLE
Fix/active navigation counter

### DIFF
--- a/src/focus/focus.js
+++ b/src/focus/focus.js
@@ -20,7 +20,7 @@ import { state } from '../router/router.js'
 import Settings from '../settings.js'
 import { DEFAULT_HOLD_TIMEOUT_MS } from '../constants.js'
 import { Log } from '../lib/log.js'
-import { getAncestors, isInAliveComponentTree } from './helpers.js'
+import { getAncestors } from './helpers.js'
 import { platform } from '../platform.js'
 
 let focusedComponent = null
@@ -41,7 +41,7 @@ export default {
     return focusedComponent
   },
   set(component, event) {
-    if (component === undefined || isInAliveComponentTree(component) === false) return
+    if (component === undefined || component.eol === true) return
 
     clearTimeout(setFocusTimeout)
 

--- a/src/focus/focus.js
+++ b/src/focus/focus.js
@@ -20,7 +20,7 @@ import { state } from '../router/router.js'
 import Settings from '../settings.js'
 import { DEFAULT_HOLD_TIMEOUT_MS } from '../constants.js'
 import { Log } from '../lib/log.js'
-import { getAncestors } from './helpers.js'
+import { getAncestors, isInAliveComponentTree } from './helpers.js'
 import { platform } from '../platform.js'
 
 let focusedComponent = null
@@ -41,7 +41,7 @@ export default {
     return focusedComponent
   },
   set(component, event) {
-    if (component === undefined || component.eol === true) return
+    if (component === undefined || isInAliveComponentTree(component) === false) return
 
     clearTimeout(setFocusTimeout)
 

--- a/src/focus/focus.test.js
+++ b/src/focus/focus.test.js
@@ -229,6 +229,32 @@ test('Ignore focus requests for destroyed components', (assert) => {
   assert.end()
 })
 
+test('Ignore focus requests for components with a destroyed ancestor', (assert) => {
+  const focusedComponent = Focus.get()
+  const destroyedParent = {
+    eol: true,
+    [symbols.lifecycle]: {
+      state: 'destroy',
+    },
+  }
+  const component = {
+    [symbols.parent]: destroyedParent,
+    [symbols.lifecycle]: {
+      state: 'init',
+    },
+  }
+
+  Focus.set(component)
+
+  assert.equal(Focus.get(), focusedComponent, 'Component with destroyed ancestor should not focus')
+  assert.equal(
+    component[symbols.lifecycle].state,
+    'init',
+    'Rejected component lifecycle should remain unchanged'
+  )
+  assert.end()
+})
+
 test('Ignore delayed focus callback when component is destroyed', (assert) => {
   const focusedComponent = Focus.get()
   const component = {

--- a/src/focus/focus.test.js
+++ b/src/focus/focus.test.js
@@ -229,32 +229,6 @@ test('Ignore focus requests for destroyed components', (assert) => {
   assert.end()
 })
 
-test('Ignore focus requests for components with a destroyed ancestor', (assert) => {
-  const focusedComponent = Focus.get()
-  const destroyedParent = {
-    eol: true,
-    [symbols.lifecycle]: {
-      state: 'destroy',
-    },
-  }
-  const component = {
-    [symbols.parent]: destroyedParent,
-    [symbols.lifecycle]: {
-      state: 'init',
-    },
-  }
-
-  Focus.set(component)
-
-  assert.equal(Focus.get(), focusedComponent, 'Component with destroyed ancestor should not focus')
-  assert.equal(
-    component[symbols.lifecycle].state,
-    'init',
-    'Rejected component lifecycle should remain unchanged'
-  )
-  assert.end()
-})
-
 test('Ignore delayed focus callback when component is destroyed', (assert) => {
   const focusedComponent = Focus.get()
   const component = {

--- a/src/focus/helpers.js
+++ b/src/focus/helpers.js
@@ -29,3 +29,22 @@ export const getAncestors = (components) => {
   }
   return components
 }
+
+/**
+ * Checks whether a component and its ancestors are alive. When root is provided,
+ * the component must also belong to that root's tree.
+ * @param {Object|undefined|null} component
+ * @param {Object|undefined|null} [root]
+ * @returns {boolean}
+ */
+export const isInAliveComponentTree = (component, root) => {
+  let current = component
+
+  while (current !== undefined && current !== null) {
+    if (current.eol === true) return false
+    if (root !== undefined && current === root) return true
+    current = current[symbols.parent]
+  }
+
+  return root === undefined
+}

--- a/src/focus/helpers.test.js
+++ b/src/focus/helpers.test.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Comcast Cable Communications Management, LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import test from 'tape'
+import symbols from '../lib/symbols.js'
+import { isInAliveComponentTree } from './helpers.js'
+
+test('Cached focus must have a live chain to the restored view', (assert) => {
+  const restoredView = {}
+  const liveParent = { [symbols.parent]: restoredView }
+  const liveFocus = { [symbols.parent]: liveParent }
+  const destroyedParent = { eol: true, [symbols.parent]: restoredView }
+  const staleFocus = { [symbols.parent]: destroyedParent }
+  const detachedFocus = {}
+
+  assert.equal(
+    isInAliveComponentTree(liveFocus, restoredView),
+    true,
+    'Live descendant should be valid cached focus'
+  )
+  assert.equal(
+    isInAliveComponentTree(staleFocus, restoredView),
+    false,
+    'Focus with a destroyed ancestor should be rejected'
+  )
+  assert.equal(
+    isInAliveComponentTree(detachedFocus, restoredView),
+    false,
+    'Focus detached from restored view should be rejected'
+  )
+  assert.end()
+})

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -84,13 +84,16 @@ let singleRouterView = null
 let activeNavigations = 0
 
 const startNavigation = () => {
-  activeNavigations++
-  state.navigating = true
+  if (activeNavigations++ === 0) {
+    state.navigating = true
+  }
 }
 
 const finishNavigation = () => {
-  activeNavigations = Math.max(0, activeNavigations - 1)
-  state.navigating = activeNavigations > 0
+  activeNavigations--
+  if (activeNavigations === 0) {
+    state.navigating = false
+  }
 }
 
 // Per-RouterView navigation state keyed by router view name.

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -80,6 +80,17 @@ export const state = reactive(
 const history = []
 const routerViews = new Set()
 let singleRouterView = null
+let activeNavigations = 0
+
+const startNavigation = () => {
+  activeNavigations++
+  state.navigating = true
+}
+
+const finishNavigation = () => {
+  activeNavigations = Math.max(0, activeNavigations - 1)
+  state.navigating = activeNavigations > 0
+}
 
 // Per-RouterView navigation state keyed by router view name.
 // When multiple router views exist, each view must have its own navigation
@@ -124,9 +135,17 @@ export const navigate = async function () {
   if (!this[symbols.parent][symbols.routes] || this[symbols.parent][symbols.routes].length === 0)
     return
 
-  if (this.history === undefined) this.history = []
+  startNavigation()
 
-  state.navigating = true
+  try {
+    await performNavigation.call(this, viewState)
+  } finally {
+    finishNavigation()
+  }
+}
+
+const performNavigation = async function (viewState) {
+  if (this.history === undefined) this.history = []
 
   Announcer.stop()
   Announcer.clear()
@@ -142,8 +161,6 @@ export const navigate = async function () {
 
   // early return when route not found
   if (route === false) {
-    state.navigating = false
-
     Log.error(`Route ${hash.hash} not found`)
     const routerHooks = this[symbols.parent][symbols.routerHooks]
     if (routerHooks && typeof routerHooks.error === 'function') {
@@ -154,7 +171,6 @@ export const navigate = async function () {
 
   // sameRouteObject is too simple check for now!
   if (this.currentRoute !== undefined && sameRouteObject(route, this.currentRoute)) {
-    state.navigating = false
     return
   }
 
@@ -176,7 +192,6 @@ export const navigate = async function () {
   )
   if (beforeEachResult === false) {
     viewState.preventHashChangeNavigation = false
-    state.navigating = false
     return
   }
 
@@ -193,7 +208,6 @@ export const navigate = async function () {
   )
   if (beforeResult === false) {
     viewState.preventHashChangeNavigation = false
-    state.navigating = false
     return
   }
 
@@ -400,7 +414,6 @@ export const navigate = async function () {
 
   // reset navigating indicators
   viewState.navigatingBack = false
-  state.navigating = false
   viewState.preventHashChangeNavigation = false
 }
 
@@ -451,7 +464,6 @@ const executeBeforeHook = async function (
         platform.historyBack()
 
         viewState.navigatingBack = false
-        state.navigating = false
       }
       return false
     }
@@ -468,7 +480,6 @@ const executeBeforeHook = async function (
         viewState.preventHashChangeNavigation = true
         platform.historyBack()
         viewState.navigatingBack = false
-        state.navigating = false
       }
       return false
     }

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -22,6 +22,7 @@ import symbols from '../lib/symbols.js'
 import { Log } from '../lib/log.js'
 import { stage } from '../launch.js'
 import Focus from '../focus/focus.js'
+import { isInAliveComponentTree } from '../focus/helpers.js'
 import Announcer from '../announcer/announcer.js'
 import Settings from '../settings.js'
 import { platform } from '../platform.js'
@@ -327,7 +328,9 @@ const performNavigation = async function (viewState) {
 
   // set focus to the view that we're routing to (unless explicitly disabling passing focus)
   if (route.options.passFocus !== false) {
-    focus ? focus.$focus() : /** @type {BlitsComponent} */ (view).$focus()
+    isInAliveComponentTree(focus, view)
+      ? /** @type {BlitsComponent} */ (focus).$focus()
+      : /** @type {BlitsComponent} */ (view).$focus()
   }
 
   // apply starting state of transition

--- a/src/router/router.test.js
+++ b/src/router/router.test.js
@@ -979,6 +979,104 @@ test('this.$router.get(name) targets a named RouterView', async (assert) => {
   }
 })
 
+test('Unchanged RouterView must not unlock input while named RouterView is navigating', async (assert) => {
+  const originalElement = stage.element
+  stage.element = ({ parent }) => ({
+    populate() {},
+    set(prop, value) {
+      if (value && value.transition && typeof value.transition.end === 'function') {
+        value.transition.end()
+      }
+    },
+    destroy() {},
+    parent,
+  })
+
+  const TestComponent = Component('ConcurrentRouterViewNavigation', {
+    template: '<Element />',
+    code: { render: () => ({ elms: [], cleanup: () => {} }), effects: [] },
+  })
+
+  let releaseNamedNavigation
+  let namedNavigationStarted
+  const namedNavigationIsStarted = new Promise((resolve) => {
+    namedNavigationStarted = resolve
+  })
+  const holdNamedNavigation = new Promise((resolve) => {
+    releaseNamedNavigation = resolve
+  })
+
+  const parent = {
+    [symbols.routes]: [
+      {
+        path: '/concurrent-main',
+        component: TestComponent,
+        options: { passFocus: false },
+      },
+      {
+        path: '/concurrent-page-one',
+        component: TestComponent,
+        options: { passFocus: false },
+      },
+      {
+        path: '/concurrent-page-two',
+        component: TestComponent,
+        options: { passFocus: false },
+        hooks: {
+          async before() {
+            namedNavigationStarted()
+            await holdNamedNavigation
+          },
+        },
+      },
+    ],
+  }
+
+  const mainRouterView = {
+    [symbols.parent]: parent,
+    [symbols.children]: [{}],
+    [symbols.props]: {},
+    name: '',
+  }
+  const namedRouterView = {
+    [symbols.parent]: parent,
+    [symbols.children]: [{}],
+    [symbols.props]: {},
+    name: 'concurrent-fv',
+  }
+
+  try {
+    to('/concurrent-main')
+    await navigate.call(mainRouterView)
+    to('/concurrent-page-one', {}, {}, namedRouterView.name)
+    await navigate.call(namedRouterView)
+
+    to('/concurrent-page-two', {}, {}, namedRouterView.name)
+    const namedNavigation = navigate.call(namedRouterView)
+    await namedNavigationIsStarted
+
+    assert.equal(state.navigating, true, 'Named RouterView should lock input while navigating')
+
+    // The same hashchange is handled by every RouterView. The main route did not
+    // change, so this navigate exits early and currently clears the shared lock.
+    await navigate.call(mainRouterView)
+
+    assert.equal(
+      state.navigating,
+      true,
+      'Unchanged RouterView must not unlock input while named navigation is still active'
+    )
+
+    releaseNamedNavigation()
+    await namedNavigation
+    assert.equal(state.navigating, false, 'Input should unlock after all navigation completes')
+  } finally {
+    releaseNamedNavigation()
+    stage.element = originalElement
+    location.hash = '#/'
+  }
+})
+
 test('Transition out with end callback is invoked on navigate away', async (assert) => {
   const originalElement = stage.element
 

--- a/src/router/router.test.js
+++ b/src/router/router.test.js
@@ -22,6 +22,7 @@ import { matchHash, getHash, setHash } from './utils.js'
 import { stage } from '../launch.js'
 import Component from '../component.js'
 import symbols from '../lib/symbols.js'
+import Focus from '../focus/focus.js'
 
 initLog()
 
@@ -719,6 +720,98 @@ test('Router.back() pops history and navigates to previous route', async (assert
   assert.ok(window.location.hash.includes('first'), 'Should set hash to previous route')
 
   stage.element = originalElement
+})
+
+test('Router falls back to the restored view when cached focus has a destroyed ancestor', async (assert) => {
+  const originalElement = stage.element
+  const originalGetFocus = Focus.get
+
+  stage.element = ({ parent }) => ({
+    populate() {},
+    set(prop, value) {
+      if (value && value.transition && typeof value.transition.end === 'function') {
+        value.transition.end()
+      }
+    },
+    destroy() {},
+    parent,
+  })
+
+  let createdViews = 0
+  let restoredViewFocusCalls = 0
+  const TestComponent = (options, holder) => {
+    const isRestoredView = createdViews++ === 0
+    return {
+      [symbols.holder]: holder,
+      $focus() {
+        if (isRestoredView) restoredViewFocusCalls++
+      },
+      destroy() {
+        this.eol = true
+      },
+    }
+  }
+
+  const host = {
+    [symbols.parent]: {
+      [symbols.routes]: [
+        {
+          path: '/stale-focus-first',
+          component: TestComponent,
+          options: { inHistory: true, keepAlive: true, passFocus: false },
+        },
+        {
+          path: '/stale-focus-second',
+          component: TestComponent,
+          options: { inHistory: true, passFocus: false },
+        },
+      ],
+    },
+    [symbols.children]: [{}],
+    [symbols.props]: {},
+    name: '',
+  }
+
+  try {
+    to('/stale-focus-first')
+    await navigate.call(host)
+    const restoredView = host.activeView
+
+    const destroyedAncestor = {
+      eol: false,
+      [symbols.parent]: restoredView,
+      [symbols.lifecycle]: { state: 'init' },
+    }
+    const cachedFocus = {
+      [symbols.parent]: destroyedAncestor,
+      [symbols.lifecycle]: { state: 'init' },
+    }
+    Focus.get = () => cachedFocus
+
+    // The cached route should pass focus when it is restored. It was disabled
+    // only for the initial navigation to keep this test independent of global
+    // focus state left by other router tests.
+    host.currentRoute.options.passFocus = true
+
+    to('/stale-focus-second')
+    await navigate.call(host)
+    Focus.get = originalGetFocus
+
+    destroyedAncestor.eol = true
+
+    assert.equal(back.call(host), true, 'Back should restore the keepAlive route')
+    await navigate.call(host)
+
+    assert.equal(
+      restoredViewFocusCalls,
+      1,
+      'Restored view should receive focus when cached focus has a destroyed ancestor'
+    )
+  } finally {
+    Focus.get = originalGetFocus
+    stage.element = originalElement
+    location.hash = '#/'
+  }
 })
 
 test('this.$router.back() uses the owning RouterView history', async (assert) => {


### PR DESCRIPTION
Fixes an issue with navigating with multiple router views and prevents focus to be delegated (restored) to (descendants of) already destroyed pages