### PR TITLE
Replaced paused boolean with a counter to ensure nested array operati…

### DIFF
--- a/src/lib/reactivity/effect.js
+++ b/src/lib/reactivity/effect.js
@@ -18,14 +18,17 @@
 let currentEffect = null
 let currentKey = null
 
-let paused = false
+// counter that tracks all pauseTracking invocations
+// to ensure nested array operations don't prematurely
+// resume before all operations have completed
+let pauseCounter = 0
 
 export const pauseTracking = () => {
-  paused = true
+  pauseCounter++
 }
 
 export const resumeTracking = () => {
-  paused = false
+  if (pauseCounter > 0) pauseCounter--
 }
 
 const objectMap = new WeakMap()
@@ -45,7 +48,7 @@ export const removeEffects = (effectsToRemove) => {
 
 export const track = (target, key) => {
   if (currentEffect !== null) {
-    if (paused) {
+    if (pauseCounter > 0) {
       return
     }
     // note: nesting the conditions like this seems to perform better ¯\_(ツ)_/¯
@@ -76,7 +79,7 @@ export const track = (target, key) => {
 }
 
 export const trigger = (target, key, force = false) => {
-  if (paused === true) return
+  if (pauseCounter > 0) return
   const effectsMap = objectMap.get(target)
   if (effectsMap === undefined) {
     return

--- a/src/lib/reactivity/effect.test.js
+++ b/src/lib/reactivity/effect.test.js
@@ -16,7 +16,7 @@
  */
 
 import test from 'tape'
-import { trigger, track, effect } from './effect.js'
+import { trigger, track, effect, pauseTracking, resumeTracking } from './effect.js'
 
 test('Trigger - type', (assert) => {
   const expected = 'function'
@@ -41,5 +41,30 @@ test('Effect - Basic Effect', (assert) => {
   }
   effect(basicEffect)
   assert.equal(data.count, 1, 'Effect should run once initially and increment count')
+  assert.end()
+})
+
+test('Tracking remains paused until every nested pause is resumed', (assert) => {
+  const target = {}
+  let effectRuns = 0
+
+  effect(() => {
+    track(target, 'value')
+    effectRuns++
+  })
+
+  pauseTracking()
+  pauseTracking()
+  resumeTracking()
+
+  trigger(target, 'value')
+
+  assert.equal(
+    effectRuns,
+    1,
+    'A nested resume should not enable tracking while an outer pause is still active'
+  )
+
+  resumeTracking()
   assert.end()
 })

--- a/src/lib/reactivity/reactive.js
+++ b/src/lib/reactivity/reactive.js
@@ -68,8 +68,12 @@ const reactiveProxy = (original, _parent = null, _key) => {
         if (arrayPatchMethods.indexOf(key) !== -1) {
           return function (...args) {
             pauseTracking()
-            const result = target[key].apply(this, args)
-            resumeTracking()
+            let result
+            try {
+              result = target[key].apply(this, args)
+            } finally {
+              resumeTracking()
+            }
             // trigger a change on the parent object and the key
             // i.e. when pushing a new item to `obj.data`, _parent will equal `obj`
             // and _key will equal `data`


### PR DESCRIPTION
This is a rare case, but theoretically a reactive array operation could happen inside another reactive array operation (i.e. pushing to another array inside a sort method). In that case the paused tracking could resume too early, which could lead to undesired side effects.

This PR fixes that by relying on a pause counter rather then a simple boolean.