### PR TITLE
Aligned relying on eol property to block callbacks after destroy. Ali…

### DIFF
--- a/src/engines/L3/element.js
+++ b/src/engines/L3/element.js
@@ -908,6 +908,7 @@ const Element = {
     if (transition.start !== undefined && typeof transition.start === 'function') {
       // fire transition start callback when animation really starts (depending on specified delay)
       f.once('animating', () => {
+        if (this.eol === true) return
         transition.start.call(this.component, this, prop, startValue)
       })
     }
@@ -929,6 +930,7 @@ const Element = {
     }
 
     f.once('stopped', () => {
+      if (this.eol === true) return
       if (
         this.scheduledTransitions[prop] !== undefined &&
         this.scheduledTransitions[prop].canceled === true
@@ -936,7 +938,7 @@ const Element = {
         return
       }
       // fire transition end callback when animation ends (if specified)
-      if (this.node !== undefined && transition.end && typeof transition.end === 'function') {
+      if (transition.end && typeof transition.end === 'function') {
         transition.end.call(this.component, this, prop, this.node[prop])
       }
       // remove the prop from scheduled transitions
@@ -1010,7 +1012,7 @@ const Element = {
     delete this.forComponent
 
     this.node.destroy()
-    this.node = null
+    this.node = undefined
   },
   get nodeId() {
     return this.node && this.node.id

--- a/src/engines/L3/element.test.js
+++ b/src/engines/L3/element.test.js
@@ -1088,7 +1088,7 @@ test('Element - Destroy created Element node', (assert) => {
   const el = createElement()
   el.set('w', { transition: { value: 100, duration: 4000 } })
   el.destroy()
-  assert.equal(el.node, null, 'Node should set to null')
+  assert.equal(el.node, undefined, 'Node should be set to undefined')
   assert.equal(el.component, undefined, 'Component should be deleted from element')
   assert.equal(el.props, undefined, 'Props should be deleted from element')
   assert.equal(el.config, undefined, 'Config should be deleted from element')
@@ -1341,13 +1341,13 @@ test('Element - Transition progress callback', (assert) => {
   }, 100)
 })
 
-test('Element - Transition end when node undefined', (assert) => {
+test('Element - Transition callbacks do not run after destroy', (assert) => {
   assert.capture(renderer, 'createNode', () => new CustomNode())
   const el = createElement()
   const endSpy = sinon.spy()
   el.set('w', { transition: { value: 100, duration: 100, end: endSpy } })
   setTimeout(() => {
-    el.node = undefined
+    el.destroy()
   }, 20)
   setTimeout(() => {
     assert.notOk(endSpy.called, 'End should not be called')


### PR DESCRIPTION
…gned resetting node property to undefined instead of null.